### PR TITLE
Integrate centered login/signup with durable setting

### DIFF
--- a/login_signup_glassdrop/index.html
+++ b/login_signup_glassdrop/index.html
@@ -115,50 +115,52 @@
       color:var(--acc2)
     }
 
-    /* Fullscreen dark glass backdrop */
+    /* Remove fullscreen overlay background/effects */
     .auth-overlay {
-    position: fixed;
-    inset: 0;
-    background: rgba(0,0,0,0.65);
-    backdrop-filter: blur(6px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 9999;
-    padding: 20px;
+      position: static;
+      inset: auto;
+      background: transparent;
+      backdrop-filter: none;
+      display: block;
+      z-index: auto;
+      padding: 0;
     }
 
-    /* Centered modal (your .card) */
+    /* Center the card itself as a floating modal */
     .auth-modal {
-    animation: popupSlide 0.35s ease-out;
-    max-height: 95vh;
-    overflow-y: auto;
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      animation: popupSlide 0.35s ease-out;
+      max-height: 95vh;
+      overflow-y: auto;
+      z-index: 2147483647;
+      box-shadow: 0 24px 80px rgba(0,0,0,.55), 0 4px 16px rgba(0,0,0,.35);
     }
 
     /* Sweet little animation */
     @keyframes popupSlide {
-    0% { transform: translateY(40px) scale(0.96); opacity: 0; }
-    100% { transform: translateY(0) scale(1); opacity: 1; }
+      0% { transform: translate(-50%, calc(-50% + 40px)) scale(0.96); opacity: 0; }
+      100% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
     }
 
     .close-btn {
-    position: fixed;
-    top: 15px;
-    right: 20px;
-    background: linear-gradient(180deg, var(--acc), #b8860b, #8b6508);
-    border: none;
-    font-size: 24px;
-    font-weight: bold;
-    color: #111; /* near-black for readability */
-    cursor: pointer;
-    z-index: 9999;
-
-    /* Better aesthetics */
-    padding: 6px 12px;
-    border-radius: 50%; /* circular button */
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
-    transition: all 0.3s ease;
-  }
+      position: absolute;
+      top: 10px;
+      right: 12px;
+      background: linear-gradient(180deg, var(--acc), #b8860b, #8b6508);
+      border: none;
+      font-size: 20px;
+      font-weight: bold;
+      color: #111; /* near-black for readability */
+      cursor: pointer;
+      z-index: 3;
+      padding: 6px 12px;
+      border-radius: 50%; /* circular button */
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+      transition: all 0.3s ease;
+    }
 
   .close-btn:hover {
     color: #fff; /* white icon on hover */


### PR DESCRIPTION
Refactor login modal styles to show only the `.card.auth-modal` as a centered popup without a fullscreen overlay. The close button is now inside the card, and the modal has a drop shadow for a floating appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea593d68-5c39-4f88-ac99-7df82c94ab44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea593d68-5c39-4f88-ac99-7df82c94ab44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

