### PR TITLE
Remove login modal backdrop overlay

### DIFF
--- a/login_signup_glassdrop/auth-gate.js
+++ b/login_signup_glassdrop/auth-gate.js
@@ -59,9 +59,9 @@
       width:100%; 
       height:100%; 
       min-height: 100%;
-      background: rgba(10,10,10,.35);
-      backdrop-filter: blur(8px) saturate(120%);
-      -webkit-backdrop-filter: blur(8px) saturate(120%);
+      background: transparent;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
     }
     #authGateModal .authgate-dialog { width: min(1100px, 98%); height: min(850px, 92%); position:relative; display:flex; flex-direction:column; overflow:hidden; }
     #authGateModal .authgate-close { position:absolute; top:10px; right:12px; z-index:3; border:none; font-size:20px; cursor:pointer; padding:6px; display:none; }


### PR DESCRIPTION
Remove the blurred, semi-transparent backdrop from the login modal to show only the login card.

---
<a href="https://cursor.com/background-agent?bcId=bc-c26e9051-d639-4b79-a813-841c43a22095">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c26e9051-d639-4b79-a813-841c43a22095">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

