### PR TITLE
Remove transparent background from login/signup

### DIFF
--- a/login_signup_glassdrop/auth-gate.js
+++ b/login_signup_glassdrop/auth-gate.js
@@ -59,7 +59,7 @@
       width:100%; 
       height:100%; 
       min-height: 100%;
-      background: transparent;
+      background: transparent !important;
       backdrop-filter: none;
       -webkit-backdrop-filter: none;
     }

--- a/login_signup_glassdrop/index.html
+++ b/login_signup_glassdrop/index.html
@@ -40,13 +40,8 @@
     header a, header button{color:var(--txt);text-decoration:none;font-weight:600;opacity:.85}
     header a:hover{opacity:1;color:var(--acc)}
     main{display:grid;place-items:center;padding:24px}
-    /* Full-page blur backdrop for auth page itself when opened directly */
-    body::before {
-      content:""; position: fixed; inset: 0; z-index: -1;
-      background: rgba(10,10,10,.35);
-      backdrop-filter: blur(8px) saturate(120%);
-      -webkit-backdrop-filter: blur(8px) saturate(120%);
-    }
+    /* Removed page-wide backdrop/blur for embedded/standalone use */
+    body::before { content: none !important; display: none !important; }
     .card{
       width:420px;max-width:95vw;
       background:linear-gradient(180deg,#1a1a1a,#0f0f0f);


### PR DESCRIPTION
Remove the transparent background behind the login/signup container.

The transparent background was caused by a `body::before` pseudo-element on the page and a backdrop style for the modal. This PR removes the page-wide overlay and ensures the modal backdrop is fully transparent.

---
<a href="https://cursor.com/background-agent?bcId=bc-c19e9800-9717-41c7-b4c7-ef965dbdf30b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c19e9800-9717-41c7-b4c7-ef965dbdf30b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

