### PR TITLE
Restore magic link ux and flow

### DIFF
--- a/login_signup_glassdrop/auth-gate.js
+++ b/login_signup_glassdrop/auth-gate.js
@@ -13,7 +13,7 @@
   // make explicit to avoid directory/index surprises:
   const LOGIN_IFRAME_URL = "https://auth.tharaga.co.in/login_signup_glassdrop/";
   // New: inline login UI rendered into the iframe via srcdoc when true
-  const USE_INLINE_LOGIN = true;
+  const USE_INLINE_LOGIN = false;
   const MAGIC_CONFIRM_URL = new URL('/magic-confirm.html', location.origin).href;
   const AUTO_RESUME_PENDING = false;
 


### PR DESCRIPTION
Revert to the dark modal login UX by disabling the inline login UI, while preserving the improved magic link flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-36ae71cf-ae4e-4f49-a434-7de5c9222b4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36ae71cf-ae4e-4f49-a434-7de5c9222b4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

