### PR TITLE
Remove welcome box from image

### DIFF
--- a/login_signup_glassdrop/auth-gate.js
+++ b/login_signup_glassdrop/auth-gate.js
@@ -441,12 +441,10 @@
   };
 
   function showParentSuccess(email) {
-    try {
-      if (!successBanner || overlay.style.display !== 'block') return;
-      successText.textContent = email ? `Welcome, ${email}! 🎉` : 'Welcome! 🎉';
-      successBanner.hidden = false;
-      setTimeout(() => { try { successBanner.hidden = true; } catch(_) {} }, 2000);
-    } catch (_) {}
+    // Disabled: do not show the green "Welcome" banner in the parent modal
+    // Keeping this function as a no-op ensures existing flows that call it
+    // (message events, cross-tab sync) still work without UI side effects.
+    return;
   }
 
   // Build inline login HTML for iframe.srcdoc


### PR DESCRIPTION
Disable the "Welcome!" banner by making `showParentSuccess` a no-op, as requested by the user, to preserve existing login flows.

---
<a href="https://cursor.com/background-agent?bcId=bc-367b687b-9b22-439e-8997-02d71a14fd08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-367b687b-9b22-439e-8997-02d71a14fd08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

