### PR TITLE
Investigate and revert welcome box removal

### DIFF
--- a/login_signup_glassdrop/auth-gate.js
+++ b/login_signup_glassdrop/auth-gate.js
@@ -441,10 +441,15 @@
   };
 
   function showParentSuccess(email) {
-    // Disabled: do not show the green "Welcome" banner in the parent modal
-    // Keeping this function as a no-op ensures existing flows that call it
-    // (message events, cross-tab sync) still work without UI side effects.
-    return;
+    try {
+      if (!successBanner || !successText) return;
+      // Restore the green welcome banner in the parent modal
+      successText.textContent = email ? ("Welcome, " + email + "!") : "Welcome!";
+      successBanner.style.background = '#f0fdf4';
+      successBanner.style.border = '1px solid #bbf7d0';
+      successBanner.style.color = '#166534';
+      successBanner.hidden = false;
+    } catch (_) {}
   }
 
   // Build inline login HTML for iframe.srcdoc


### PR DESCRIPTION
Re-enable the parent modal's welcome banner by restoring the `showParentSuccess` function.

This PR reverts a previous change (commit 6d7e9c3) that disabled the parent modal's welcome banner. The user requested this revert, indicating the banner should be re-enabled.

---
<a href="https://cursor.com/background-agent?bcId=bc-c387d55b-9bba-411b-ad46-b9cdea968734">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c387d55b-9bba-411b-ad46-b9cdea968734">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

