### PR TITLE
Fix magic link auth button error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,22 +7,18 @@
   from = "/auth-email-landing"
   to = "/auth-email-landing/"
   status = 301
-  force = true
 
 [[redirects]]
   from = "/login_signup_glassdrop"
   to = "/login_signup_glassdrop/"
   status = 301
-  force = true
 
 [[redirects]]
   from = "/auth-landing"
   to = "/auth-landing/"
   status = 301
-  force = true
 
 [[redirects]]
   from = "/reset_password/*"
   to = "/Reset_password/:splat"
   status = 301
-  force = true


### PR DESCRIPTION
Remove `force = true` from Netlify redirect rules to fix infinite redirect loops on authentication pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-03d2cd5a-44ff-4395-947c-e3709d7246a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03d2cd5a-44ff-4395-947c-e3709d7246a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

