### PR TITLE
Fix magic link login and redirect

### DIFF
--- a/login_signup_glassdrop/index.html
+++ b/login_signup_glassdrop/index.html
@@ -240,7 +240,8 @@
     const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndlZGV2dGpqbWR2bmd5c2hxZHJvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU0NzYwMzgsImV4cCI6MjA3MTA1MjAzOH0.Ex2c_sx358dFdygUGMVBohyTVto6fdEQ5nydDRh9m6M'; // <-- REQUIRED
 
     const __qs = new URLSearchParams(location.search);
-    const FALLBACK_PARENT_ORIGIN = 'https://tharaga.co.in';
+    // Prefer current origin so the email redirect callback lands on the same origin (enables storage/postMessage)
+    const FALLBACK_PARENT_ORIGIN = location.origin;
     const PARENT_ORIGIN = (__qs.get('parent_origin') || FALLBACK_PARENT_ORIGIN || location.origin).replace(/\/$/, '');
     const HANDOFF_STATE = (__qs.get('state') || (function(){ try { return JSON.parse(localStorage.getItem('__tharaga_auth_state')||'null')?.state||null; } catch(_) { return null; } })());
     //const POST_AUTH_CALLBACK = `https://auth.tharaga.co.in/login_signup_glassdrop/?post_auth=1&parent_origin=${encodeURIComponent(PARENT_ORIGIN)}`;

--- a/public/auth/callback.html
+++ b/public/auth/callback.html
@@ -63,17 +63,33 @@
       try { bc && bc.postMessage({ type:'THARAGA_AUTH_SUCCESS', next }); } catch(e){ dbg('bc.err', e); }
       try {
         if (window.opener && !window.opener.closed) {
-          window.opener.postMessage({ type: 'THARAGA_AUTH_SUCCESS', next }, location.origin);
-          dbg('postMessage to opener', true);
+          // Also notify opener in a cross-origin friendly way
+          try { window.opener.postMessage({ type: 'THARAGA_AUTH_SUCCESS', next }, '*'); } catch(_) {}
         }
       } catch (e) { dbg('postMessage.err', e); }
       setLocalMarker({ ts: Date.now(), next });
     }
 
+    // Post useful events to the opener, including tokens for same-origin session creation on auth host
+    async function notifyOpenerWithTokens(tokens){
+      try {
+        if (!window.opener || window.opener.closed) return;
+        const { access_token, refresh_token, user } = tokens || {};
+        const payloadUser = user ? { id: user.id || null, email: user.email || null } : null;
+        // 1) Generic signed_in message (no tokens required)
+        try { window.opener.postMessage({ type: 'signed_in', user: payloadUser, next }, '*'); } catch(_) {}
+        // 2) Token transfer so auth origin can establish a real session
+        if (access_token && refresh_token) {
+          const tokenMsg = { type: 'tharaga_token_transfer', access_token, refresh_token, next, user: payloadUser };
+          try { window.opener.postMessage(tokenMsg, '*'); } catch(_) {}
+        }
+      } catch (e) { dbg('notifyOpenerWithTokens.err', e); }
+    }
+
     function finalRedirect(){
+      // Do NOT auto-redirect to home. Close if possible; otherwise, keep this friendly page open.
       setTimeout(() => {
         try { window.close(); dbg('window.close() attempted', true); } catch(e){ dbg('window.close.err', e); }
-        try { location.replace(next); dbg('location.replace', next); } catch(e){ dbg('location.replace.err', e); }
       }, 700);
     }
 
@@ -90,6 +106,17 @@
     async function finishWithSession(note){
       dbg('finishWithSession', note);
       onSuccessDisplay();
+      try {
+        const { data } = await supabase.auth.getSession();
+        const tok = {
+          access_token: data?.session?.access_token || null,
+          refresh_token: data?.session?.refresh_token || null,
+          user: data?.session?.user || null
+        };
+        // Write continue signal so same-origin tabs update immediately
+        try { localStorage.setItem('__tharaga_magic_continue', JSON.stringify({ ts: Date.now(), next, user: tok.user ? { id: tok.user.id, email: tok.user.email } : null })); } catch(_) {}
+        await notifyOpenerWithTokens(tok);
+      } catch (e) { dbg('getSession.afterFinish.err', e); }
       notifySuccess();
       finalRedirect();
     }
@@ -110,6 +137,8 @@
             const { data, error } = await supabase.auth.setSession({ access_token, refresh_token });
             if (error) throw error;
             dbg('setSession succeeded', data);
+            // Inform opener immediately using the tokens we already have
+            try { await notifyOpenerWithTokens({ access_token, refresh_token, user: data?.session?.user || null }); } catch(_) {}
             await finishWithSession('setSession');
             return;
           }
@@ -129,6 +158,7 @@
           const { data, error } = await supabase.auth.exchangeCodeForSession(code);
           if (error) throw error;
           dbg('exchangeCodeForSession', data);
+          try { await notifyOpenerWithTokens({ access_token: data?.session?.access_token || null, refresh_token: data?.session?.refresh_token || null, user: data?.session?.user || null }); } catch(_) {}
           await finishWithSession('exchangeCodeForSession');
           return;
         }


### PR DESCRIPTION
Stop magic link callback from auto-redirecting and enable the original tab to update its logged-in state.

Previously, clicking a magic link would open a new tab that redirected to the home page (`tharaga.co.in/#`), while the original tab remained on the login screen. This change ensures the new tab attempts to close or stays on a success message, and the original tab receives the session information to update its UI to a logged-in state.

---
<a href="https://cursor.com/background-agent?bcId=bc-9380f81c-590b-457b-8eda-54cb51aa2777">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9380f81c-590b-457b-8eda-54cb51aa2777">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

