### PR TITLE
Debug database error saving new user

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     headless: true,
   },
   webServer: {
-    command: 'npx sirv-cli public --single --port 4173',
+    command: 'npx sirv-cli . --single --port 4173',
     port: 4173,
     reuseExistingServer: true,
   },

--- a/supabase/migrations/001_auth_profiles.sql
+++ b/supabase/migrations/001_auth_profiles.sql
@@ -1,0 +1,95 @@
+-- Create profiles table and a safe trigger to populate it from auth.users
+-- This avoids signup failures due to strict constraints or failing triggers.
+
+-- 1) profiles table (in public schema)
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  email text,
+  full_name text,
+  avatar_url text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Keep email unique only if not null to avoid conflicts with social providers missing email
+create unique index if not exists profiles_email_unique on public.profiles(email) where email is not null;
+
+-- 2) updated_at maintenance trigger
+create or replace function public.handle_profiles_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at := now();
+  return new;
+end;$$;
+
+drop trigger if exists on_profiles_updated_at on public.profiles;
+create trigger on_profiles_updated_at
+before update on public.profiles
+for each row execute function public.handle_profiles_updated_at();
+
+-- 3) Safe mirror from auth.users -> public.profiles
+create or replace function public.handle_new_user()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  v_email text;
+  v_name text;
+  v_avatar text;
+begin
+  -- Extract optional values from raw_user_meta_data
+  begin
+    v_email := new.email;
+  exception when others then
+    v_email := null;
+  end;
+
+  begin
+    v_name := coalesce((new.raw_user_meta_data ->> 'full_name'), (new.raw_user_meta_data ->> 'name'));
+  exception when others then
+    v_name := null;
+  end;
+
+  begin
+    v_avatar := (new.raw_user_meta_data ->> 'avatar_url');
+  exception when others then
+    v_avatar := null;
+  end;
+
+  -- Insert if not exists; never raise on conflict
+  insert into public.profiles(id, email, full_name, avatar_url)
+  values (new.id, v_email, v_name, v_avatar)
+  on conflict (id) do update set
+    email = excluded.email,
+    full_name = excluded.full_name,
+    avatar_url = excluded.avatar_url,
+    updated_at = now();
+
+  return new;
+exception when others then
+  -- Swallow any unexpected error to avoid breaking auth signup
+  return new;
+end;$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute function public.handle_new_user();
+
+-- 4) RLS: allow users to view and update their own profile
+alter table public.profiles enable row level security;
+
+do $$ begin
+  perform 1 from pg_policies where schemaname = 'public' and tablename = 'profiles' and policyname = 'Public profiles are viewable by authenticated users';
+  if not found then
+    create policy "Public profiles are viewable by authenticated users"
+      on public.profiles for select using ( auth.uid() is not null );
+  end if;
+end $$;
+
+do $$ begin
+  perform 1 from pg_policies where schemaname = 'public' and tablename = 'profiles' and policyname = 'Users can update own profile';
+  if not found then
+    create policy "Users can update own profile"
+      on public.profiles for update using ( auth.uid() = id ) with check ( auth.uid() = id );
+  end if;
+end $$;
+

--- a/tests/playwright/auth.spec.ts
+++ b/tests/playwright/auth.spec.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import { test, expect } from '@playwright/test';
+
+test.describe('Signup flow', () => {
+  test('shows friendly error on duplicate email and succeeds on new email', async ({ page }) => {
+    const base = 'http://localhost:4173/login_signup_glassdrop/';
+    await page.goto(base);
+
+    // Helper to attempt signup
+    const doSignup = async (email: string, password: string) => {
+      await page.getByLabel('Email').fill(email);
+      await page.getByLabel('Password').fill(password);
+      await page.getByRole('button', { name: 'Create account' }).click();
+      await page.waitForTimeout(400); // allow UI to update
+      return page.locator('#msg').textContent();
+    };
+
+    const unique = `u${Date.now()}@example.com`;
+
+    // First time should create account or show success message
+    const first = await doSignup(unique, 'password123');
+    expect(first || '').toMatch(/Account created|already registered|rate/i);
+
+    // Second time with same email should not crash the page
+    const second = await doSignup(unique, 'password123');
+    expect(second || '').not.toMatch(/Database error saving new user/i);
+  });
+});
+


### PR DESCRIPTION
Add a `public.profiles` table and a resilient `auth.users` insert trigger to prevent new user signup failures.

The "Database error saving new user" often occurs when a strict trigger or profile creation fails during `auth.users` insertion. This PR introduces a `public.profiles` table and a robust `auth.users` AFTER INSERT trigger that uses `ON CONFLICT` and error swallowing to ensure user signup is never blocked, even if profile data mirroring encounters issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb8356cf-69b6-4e04-9821-a4f3d280267f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb8356cf-69b6-4e04-9821-a4f3d280267f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

