### PR TITLE
Fix buyer form and search filter login

### DIFF
--- a/buyer-form/index.html
+++ b/buyer-form/index.html
@@ -771,7 +771,7 @@ async function getRecaptcha() {
   e.preventDefault();
 
   // Check session
-  const currentUser = await ensureSupabaseSession?.() || (await window.supabase?.auth.getSession()).data?.session?.user || null;
+  const currentUser = await (window.ensureSupabaseSession?.()) || (await window.supabase?.auth.getSession()).data?.session?.user || null;
   if (!currentUser) {
     // persist current form to restore after auth
     try {
@@ -1002,6 +1002,8 @@ async function ensureSupabaseSession() {
   }
   return null;
 }
+// expose globally for other scripts to call
+window.ensureSupabaseSession = ensureSupabaseSession;
 // pick up the popup's postMessage if it sends one
 window.addEventListener('message', (ev) => {
   try {

--- a/search-filter-home/index.html
+++ b/search-filter-home/index.html
@@ -4,6 +4,16 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <script type="module" src="/js/fragment-handle.js"></script>
+  <!-- Durable Auth: modal + gating (shared across pages) -->
+  <script src="https://auth.tharaga.co.in/login_signup_glassdrop/auth-gate.js" defer></script>
+  <script>
+    window.DURABLE_AUTH_URL = 'https://auth.tharaga.co.in/login_signup_glassdrop/';
+    window.AUTH_NAV = { profile: '/profile', dashboard: '/dashboard' };
+  </script>
+  <style>
+    /* Hide the header auth button if injected by shared code; keep only modal/gating */
+    .thg-auth-wrap{ display:none !important; }
+  </style>
   <!-- use ONE include, absolute path, and defer it so DOM is present -->
   <title>Tharaga — Home Search</title>
 


### PR DESCRIPTION
Fix buyer form submission gating by exposing the session helper globally and enable login modal on search filter page by integrating durable auth.

The buyer form's submit button was not correctly enabling/disabling due to a scope issue with `ensureSupabaseSession` after a recent commit. Exposing it globally resolves this. The search filter page now correctly displays the login modal when a user clicks "Search" without being logged in, providing a smoother user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-cedce989-cfde-40a5-9ffe-482d463a3423">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cedce989-cfde-40a5-9ffe-482d463a3423">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

