### PR TITLE
Fix login container and redirect google auth

### DIFF
--- a/snippets/durable-auth-head.html
+++ b/snippets/durable-auth-head.html
@@ -128,7 +128,29 @@
 
   function ready(fn){ if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',fn,{once:true});} else { fn(); } }
   function headerRoot(){ return document.querySelector('header, [role="banner"], [data-section="header"], .site-header, .Header, nav') || null; }
-  function hideLegacyAuthLinks(root){ (root||document).querySelectorAll('a[href="#login"], a[href="#signup"], [data-auth-open]').forEach(function(el){ el.style.display='none'; el.setAttribute('aria-hidden','true'); }); }
+  // Instead of hiding legacy/login links, wire them to trigger the header auth button
+  function hideLegacyAuthLinks(root){
+    var scope = (root || document);
+    var selector = 'a[href="#login"], a[href="#signup"], [data-auth-open]';
+    scope.querySelectorAll(selector).forEach(function(el){
+      if (el.__thgAuthWired) return;
+      el.__thgAuthWired = true;
+      el.addEventListener('click', function(ev){
+        try {
+          ev.preventDefault();
+          // Prefer triggering the existing header Login/Signup button
+          var btn = document.querySelector('.thg-auth-btn');
+          if (btn) { btn.click(); return; }
+          // Fallback to opening the modal directly
+          if (window.authGate && typeof window.authGate.openLoginModal === 'function') {
+            window.authGate.openLoginModal({ next: location.pathname + location.search });
+          } else if (typeof window.__thgOpenAuthModal === 'function') {
+            window.__thgOpenAuthModal({ next: location.pathname + location.search });
+          }
+        } catch(_){ }
+      }, { passive:false });
+    });
+  }
   function clamp(str, max){ if (!str) return ''; return str.length>max ? str.slice(0,max-1)+'…' : str; }
   function getInitials(user){
     const meta = user?.user_metadata || {};
@@ -424,6 +446,11 @@
     ui.confirmEl.addEventListener('click', function(e){ if (e.target === ui.confirmEl) closeConfirm(ui); });
     ui.confirmEl.querySelector('.thg-confirm-ok').addEventListener('click', async function(){ try { await window.supabase?.auth?.signOut?.(); } catch(_){} closeConfirm(ui); });
     window.__thgOpenAuthModal = function(opts){ openAuthModal(ui, opts); };
+    // Expose a helper to programmatically trigger the header button from anywhere
+    window.authGate.triggerHeaderLogin = function(opts){
+      try { ui.btn && ui.btn.click(); }
+      catch(_){ try { openAuthModal(ui, opts||{ next: location.pathname + location.search }); } catch(__){} }
+    };
   }
 
   async function initSupabase(ui){


### PR DESCRIPTION
Wire in-page login/signup links to trigger the header's auth button to ensure a consistent login experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-958c980b-be15-4853-bece-e6a6542cbfa8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-958c980b-be15-4853-bece-e6a6542cbfa8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

