### PR TITLE
Fix header login signup button display

### DIFF
--- a/login_signup_glassdrop/auth-gate.js
+++ b/login_signup_glassdrop/auth-gate.js
@@ -53,20 +53,18 @@
 
   const style = document.createElement('style');
   style.textContent = `
-    #authGateModal { position: absolute; inset: 0; top: 0; 
-    left: 0;
-    width: 100%; 
-    min-height: 100%; display: none; z-index: 2147483646; }
+    /* Use fixed positioning so the overlay always covers the entire viewport
+       regardless of ancestor positioning/overflow/transform contexts. */
+    #authGateModal { position: fixed; inset: 0; left: 0; width: 100vw; height: 100vh; display: none; z-index: 2147483646; }
     #authGateModal .authgate-backdrop { display:flex; align-items:center; justify-content:center; inset:0;
       display:flex; 
       align-items:center; 
       justify-content:center; 
-      position:absolute; 
+      position:fixed; 
       top:0; 
       left:0; 
-      width:100%; 
-      height:100%; 
-      min-height: 100%;
+      width:100vw; 
+      height:100vh; 
       background: rgba(10,10,10,.35);
       backdrop-filter: blur(8px) saturate(120%);
       -webkit-backdrop-filter: blur(8px) saturate(120%);


### PR DESCRIPTION
Update auth modal and backdrop positioning to `fixed` to ensure it covers the full viewport and is not clipped.

The previous `position: absolute` for `#authGateModal` and `.authgate-backdrop` caused the login/signup modal to be clipped by parent containers, preventing it from appearing as a full-screen overlay with a dimmed backdrop. Changing to `position: fixed` with `100vw` and `100vh` ensures it always covers the entire viewport, matching the expected behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac7ff14b-69a4-4a07-b0c1-b95955232a9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac7ff14b-69a4-4a07-b0c1-b95955232a9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

