### PR TITLE
Integrate durable auth head into buyer form

### DIFF
--- a/buyer-form/index.html
+++ b/buyer-form/index.html
@@ -7,7 +7,8 @@
   <link rel="stylesheet" href="./style.css">
   <script type="module" src="/js/fragment-handle.js"></script>
   
-  <script>
+  <!-- Inline auth removed; using durable-auth-head.html -->
+  <!-- <script>
 // Durable top-right authentication header and modal (Supabase-based)
 // Works standalone when pasted into Durable Head Code
 (function(){
@@ -311,7 +312,7 @@
 
   ready(function(){ hideLegacyAuthLinks(document); injectStyles(); const ui = createUI(); bindUI(ui); observeRerenders(); initSupabase(ui); window.addEventListener('storage', function(ev){ if (ev.key === 'supabase.auth.token'){ } }); window.addEventListener('beforeunload', function(){ try { state.sub && state.sub.unsubscribe && state.sub.unsubscribe(); } catch(_){} }); });
 })();
-  </script>
+  </script> -->
   <!-- Unified auth overlay include (overrides any legacy handlers) -->
   <script>
     window.DURABLE_AUTH_URL = 'https://auth.tharaga.co.in/login_signup_glassdrop/';


### PR DESCRIPTION
Remove inline login/signup modal from buyer-form to use the global auth header.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8fa4fb1-7d44-41d4-b206-3695715eee39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8fa4fb1-7d44-41d4-b206-3695715eee39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

