### PR TITLE
Link buyer and search CTA to auth head

### DIFF
--- a/search-filter-home/index.html
+++ b/search-filter-home/index.html
@@ -289,19 +289,20 @@
             if (!loggedIn && window.__authGateLoggedIn) loggedIn = true;
             if (loggedIn) { runGo(); return; }
             evt.preventDefault && evt.preventDefault();
-            // Fallback: if auth modal isnt available here, just proceed with search
-            if (!window.authGate || typeof window.authGate.openLoginModal !== 'function') { runGo(); return; }
             const next = (location.pathname + location.search);
-            window.authGate.openLoginModal({ next });
+            if (window.authGate && typeof window.authGate.triggerHeaderLogin === 'function') {
+              try { window.authGate.triggerHeaderLogin({ next }); } catch(_) {}
+              return;
+            }
+            if (window.authGate && typeof window.authGate.openLoginModal === 'function') {
+              try { window.authGate.openLoginModal({ next }); } catch(_) {}
+              return;
+            }
+            runGo();
           } catch (e) { console.error('manualGateHandler error', e); }
         }
 
-        if (window.authGate && typeof window.authGate.attachAuthGate === 'function') {
-          window.authGate.attachAuthGate('#homeSearchBtn', async () => { runGo(); });
-        } else {
-          btnEl.addEventListener('click', manualGateHandler, { passive: false });
-          setTimeout(setupSearchClick, 400);
-        }
+        btnEl.addEventListener('click', manualGateHandler, { passive: false });
 
         qEl.addEventListener('keydown', (e) => {
           if (e.key === 'Enter') { e.preventDefault(); btnEl.click(); }


### PR DESCRIPTION
Unify the "Search" CTA button in `search-filter-home/index.html` to trigger the main header login modal.

This change prevents duplicate login UI and ensures a consistent user experience by leveraging the existing `window.authGate.triggerHeaderLogin` mechanism, aligning it with the top-right login/signup button and removing a separate iframe-based gating path.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1537cf7-1ab9-4d9f-839f-875ba1927e63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f1537cf7-1ab9-4d9f-839f-875ba1927e63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

