### PR TITLE
Link buyer form cta to login signup container

### DIFF
--- a/buyer-form/index.html
+++ b/buyer-form/index.html
@@ -6,7 +6,7 @@
   <title>Tharaga — Verified Buyer Match</title>
   <link rel="stylesheet" href="./style.css">
   <script type="module" src="/js/fragment-handle.js"></script>
-  <script src="https://auth.tharaga.co.in/login_signup_glassdrop/auth-gate.js" defer></script>
+  <!-- Auth header/modal: use the durable snippet so CTA can open the global login container -->
   
   <!-- Inline auth removed; using durable-auth-head.html -->
   <!-- <script>
@@ -319,6 +319,383 @@
     window.DURABLE_AUTH_URL = 'https://auth.tharaga.co.in/login_signup_glassdrop/';
     window.AUTH_NAV = { profile: '/profile', dashboard: '/dashboard' };
   </script>
+  
+  <!-- Include durable-auth-head snippet (same code as used site-wide in header) -->
+  <!-- BEGIN durable-auth-head.html include -->
+  <!-- 1) Load auth-gate (handles iframe auth modal + cross-tab sync) -->
+  <script src="https://auth.tharaga.co.in/login_signup_glassdrop/auth-gate.js" defer></script>
+
+  <!-- 2) Configure globals before the header script runs -->
+  <script>
+    window.DURABLE_AUTH_URL = 'https://auth.tharaga.co.in/login_signup_glassdrop/';
+    window.AUTH_NAV = { profile: '/profile', dashboard: '/dashboard' };
+  </script>
+
+  <!-- 3) No separate header UI script is required. Auth modal is provided by auth-gate. -->
+
+  <!-- 4) Inline durable auth header UI (safe to paste into Durable Head Code) -->
+  <script>
+  // Durable top-right authentication header and modal (Supabase-based)
+  // Works standalone when pasted into Durable Head Code
+  (function(){
+    if (window.__thgAuthInstalledV1) return; window.__thgAuthInstalledV1 = true;
+
+    const AUTH_NAV = Object.assign({ profile: '/profile', dashboard: '/dashboard', settings: null }, window.AUTH_NAV || {});
+    const Z_BASE = 2147483000;
+
+    window.authGate = window.authGate || {};
+    window.authGate.openLoginModal = function(opts){ (window.__thgOpenAuthModal || function(){ alert('Auth not ready'); })(opts||{}); };
+
+    function ready(fn){ if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',fn,{once:true});} else { fn(); } }
+    function headerRoot(){ return document.querySelector('header, [role="banner"], [data-section="header"], .site-header, .Header, nav') || null; }
+    // Instead of hiding legacy/login links, wire them to trigger the header auth button
+    function hideLegacyAuthLinks(root){
+      var scope = (root || document);
+      var selector = 'a[href="#login"], a[href="#signup"], [data-auth-open]';
+      scope.querySelectorAll(selector).forEach(function(el){
+        if (el.__thgAuthWired) return;
+        el.__thgAuthWired = true;
+        el.addEventListener('click', function(ev){
+          try {
+            ev.preventDefault();
+            // Prefer triggering the existing header Login/Signup button
+            var btn = document.querySelector('.thg-auth-btn');
+            if (btn) { btn.click(); return; }
+            // Fallback to opening the modal directly
+            if (window.authGate && typeof window.authGate.openLoginModal === 'function') {
+              window.authGate.openLoginModal({ next: location.pathname + location.search });
+            } else if (typeof window.__thgOpenAuthModal === 'function') {
+              window.__thgOpenAuthModal({ next: location.pathname + location.search });
+            }
+          } catch(_){ }
+        }, { passive:false });
+      });
+    }
+    function clamp(str, max){ if (!str) return ''; return str.length>max ? str.slice(0,max-1)+'…' : str; }
+    function getInitials(user){
+      const meta = user?.user_metadata || {};
+      const full = (meta.full_name || meta.name || '').trim();
+      if (full) {
+        const parts = full.split(/\s+/).filter(Boolean);
+        const first = parts[0]?.[0] || '';
+        const last = parts.length>1 ? parts[parts.length-1][0] : '';
+        return (first+last || first || '').toUpperCase() || 'U';
+      }
+      const email = (user?.email || '').trim();
+      return email ? email[0].toUpperCase() : 'U';
+    }
+    function getDisplayName(user){
+      const meta = user?.user_metadata || {};
+      const name = (meta.full_name || meta.name || meta.username || '').trim();
+      return name || (user?.email || 'My Account');
+    }
+    function createEl(tag, cls, attrs){ const el = document.createElement(tag); if (cls) el.className = cls; if (attrs) for (var k in attrs) el.setAttribute(k, attrs[k]); return el; }
+
+    function ensureContainer(){
+      let hdr = headerRoot();
+      let wrap = document.querySelector('.thg-auth-wrap');
+      if (!wrap){
+        wrap = document.createElement('div');
+        wrap.className = 'thg-auth-wrap';
+        let parent = hdr || document.body;
+        if (hdr) { const cs = getComputedStyle(hdr); if (cs.position === 'static') { hdr.style.position = 'relative'; } parent.appendChild(wrap); }
+        else { wrap.classList.add('is-fixed'); parent.appendChild(wrap); }
+      }
+      return wrap;
+    }
+
+    function injectStyles(){
+      if (document.getElementById('thg-auth-styles')) return;
+      const css = `
+.thg-auth-wrap{ position:absolute; top:14px; right:16px; display:flex; align-items:center; z-index:${Z_BASE}; }
+@media (min-width:1024px){ .thg-auth-wrap{ top:16px; right:24px; } }
+.thg-auth-wrap.is-fixed{ position:fixed; top:14px; right:16px; }
+
+/* Header button */
+.thg-auth-btn{ appearance:none;background:transparent;color:#fff;border:1px solid rgba(255,255,255,.9); border-radius:9999px;padding:8px 14px;font-weight:600;cursor:pointer;line-height:1;white-space:nowrap;display:inline-flex;align-items:center;gap:8px; transition:background .15s ease, border-color .15s ease, box-shadow .15s ease; }
+.thg-auth-btn:hover{background:rgba(255,255,255,.08)}
+.thg-auth-btn:focus-visible{ outline:2px solid #7dd3fc; outline-offset:2px; }
+.thg-auth-btn .thg-initial{ width:22px;height:22px;border-radius:9999px;background:#fff;color:#111;display:none;align-items:center;justify-content:center;font-weight:700;font-size:11px; }
+.thg-auth-btn.is-auth .thg-initial{ display:inline-flex; }
+.thg-auth-btn.is-auth::after{ content:""; display:inline-block; width:0; height:0; border-left:5px solid transparent; border-right:5px solid transparent; border-top:6px solid rgba(255,255,255,.9); transition:transform .15s ease; transform-origin:center; }
+.thg-auth-btn[aria-expanded="true"].is-auth::after{ transform:rotate(180deg); }
+.thg-spinner{ width:14px;height:14px;border-radius:9999px;border:2px solid rgba(255,255,255,.35);border-top-color:#fff; animation:thgspin .8s linear infinite; }
+@keyframes thgspin{ to{ transform:rotate(360deg); } }
+
+/* Account menu */
+.thg-auth-menu{ position:absolute;top:calc(100% + 10px);right:0;min-width:280px;background:#0b0b0b;color:#fff; border:1px solid rgba(255,255,255,.15);border-radius:12px;padding:8px;box-shadow:0 12px 30px rgba(0,0,0,.45); visibility:hidden; opacity:0; transform:translateY(-6px) scale(.98); transform-origin:top right; pointer-events:none; transition:opacity .16s ease, transform .16s ease, visibility 0s linear .16s; z-index:${Z_BASE+1}; }
+.thg-auth-menu[aria-hidden="false"]{ visibility:visible; opacity:1; transform:translateY(0) scale(1); pointer-events:auto; transition:opacity .16s ease, transform .16s ease, visibility 0s linear 0s; }
+.thg-auth-item{ display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:10px;text-decoration:none;color:#fff;cursor:pointer; }
+.thg-auth-item:hover{background:rgba(255,255,255,.08)}
+.thg-auth-item[tabindex]{outline:none}
+.thg-auth-item.is-header{ cursor:default;font-weight:700;opacity:.95; }
+.thg-auth-item.is-header:hover{background:transparent}
+.thg-auth-sep{ height:1px;background:rgba(255,255,255,.12);margin:6px 8px;border-radius:1px; }
+.thg-initial-lg{ width:28px;height:28px;border-radius:9999px;background:#fff;color:#111;display:inline-flex;align-items:center;justify-content:center;font-weight:700;font-size:12px; }
+.thg-name-wrap{ display:flex; flex-direction:column; min-width:0; }
+.thg-name{ overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:190px; }
+.thg-email{ opacity:.7; font-size:12px; overflow:hidden;text-overflow:ellipsis;white-space:nowrap; max-width:200px; }
+
+/* Modal */
+.thg-auth-overlay{ position:fixed; inset:0; background:rgba(0,0,0,.55); backdrop-filter:saturate(140%) blur(6px); display:flex; align-items:center; justify-content:center; z-index:${Z_BASE+2}; visibility:hidden; opacity:0; transition:opacity .18s ease, visibility 0s linear .18s; }
+.thg-auth-overlay[aria-hidden="false"]{ visibility:visible; opacity:1; transition:opacity .18s ease, visibility 0s linear 0s; }
+.thg-auth-modal{ width:100%; max-width:420px; background:linear-gradient(180deg, rgba(20,20,20,.98), rgba(12,12,12,.98)); color:#fff; border:1px solid rgba(255,255,255,.1); border-radius:16px; box-shadow:0 30px 60px rgba(0,0,0,.5); transform:translateY(10px) scale(.98); opacity:0; transition:transform .18s ease, opacity .18s ease; }
+.thg-auth-overlay[aria-hidden="false"] .thg-auth-modal{ transform:translateY(0) scale(1); opacity:1; }
+.thg-auth-header{ display:flex; align-items:center; justify-content:space-between; padding:16px 18px; border-bottom:1px solid rgba(255,255,255,.08); }
+.thg-auth-title{ font-weight:800; font-size:20px; }
+.thg-auth-close{ appearance:none; background:linear-gradient(180deg,#f3cd4a,#eab308,#c58a04); border:0; color:#111; cursor:pointer; font-weight:800; width:32px; height:32px; line-height:32px; border-radius:9999px; box-shadow:0 2px 6px rgba(0,0,0,.25); }
+.thg-auth-close:hover{ color:#fff; background:linear-gradient(180deg,#eab308,#c58a04,#7a5200); transform:scale(1.06); }
+.thg-auth-body{ padding:16px 18px 18px; }
+
+/* Tabs */
+.thg-tabs{ display:flex; gap:6px; background:rgba(255,255,255,.06); padding:4px; border-radius:9999px; margin-bottom:16px; }
+.thg-tab{ flex:1; text-align:center; padding:8px 10px; border-radius:9999px; cursor:pointer; font-weight:700; color:#ddd; }
+.thg-tab[aria-selected="true"]{ background:#fff; color:#111; }
+
+/* Fields */
+.thg-field{ display:flex; flex-direction:column; gap:6px; margin-bottom:12px; }
+.thg-field label{ font-size:12px; opacity:.9; }
+.thg-field label[for="thg-si-password"]::after{ content:" (optional — use Magic Link for fastest login)"; color:#9ca3af; font-weight:500; }
+.thg-input{ appearance:none; background:#121212; color:#fff; border:1px solid rgba(255,255,255,.12); border-radius:10px; padding:10px 12px; }
+.thg-input::placeholder{ color:#6b7280; }
+.thg-input:focus{ outline:2px solid #facc15; outline-offset:2px; }
+
+/* Actions and links */
+.thg-actions{ display:flex; justify-content:space-between; align-items:center; margin:6px 0 12px; }
+.thg-link{ background:none; border:0; color:#22c55e; cursor:pointer; font-size:13px; padding:0; }
+
+/* Primary CTA (yellow) */
+.thg-btn-primary{ width:100%; appearance:none; background:linear-gradient(180deg,#f8d34a,#f0b90b,#c89200); color:#111; border:1px solid rgba(250, 204, 21, .9); border-radius:12px; padding:12px 14px; font-weight:800; cursor:pointer; transition:transform .06s ease, box-shadow .06s ease, filter .12s ease; box-shadow:0 4px 0 rgba(250, 204, 21, .35); }
+.thg-btn-primary:hover{ filter:brightness(1.03); }
+.thg-btn-primary:active{ transform:translateY(1px); box-shadow:none; }
+
+/* OAuth / secondary buttons */
+.thg-oauth{ display:grid; grid-template-columns:1fr; gap:10px; margin-top:10px; }
+.thg-oauth-btn{ appearance:none; background:#0f0f0f; color:#fff; border:1px solid rgba(255,255,255,.12); border-radius:12px; padding:12px 14px; cursor:pointer; font-weight:800; }
+
+/* Errors, hints, loading */
+.thg-error{ background:rgba(239,68,68,.12); color:#fecaca; border:1px solid rgba(239,68,68,.35); border-radius:10px; padding:10px 12px; font-size:13px; display:none; }
+.thg-hint{ font-size:12px; opacity:.8; }
+.thg-loading-bar{ height:2px; width:0; background:#7dd3fc; border-radius:2px; transition:width .2s ease; }
+
+/* Confirm dialog */
+.thg-confirm{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; z-index:${Z_BASE+3}; background:rgba(0,0,0,.55); backdrop-filter:blur(3px); visibility:hidden; opacity:0; transition:opacity .16s ease, visibility 0s linear .16s; }
+.thg-confirm[aria-hidden="false"]{ visibility:visible; opacity:1; transition:opacity .16s ease, visibility 0s linear 0s; }
+.thg-confirm-card{ width:100%; max-width:360px; background:#141414; color:#fff; border:1px solid rgba(255,255,255,.12); border-radius:12px; padding:16px; box-shadow:0 24px 50px rgba(0,0,0,.5); }
+.thg-confirm-actions{ display:flex; gap:10px; justify-content:flex-end; margin-top:12px; }
+.thg-btn{ appearance:none; border-radius:10px; padding:8px 12px; cursor:pointer; border:1px solid rgba(255,255,255,.15); background:#0f0f0f; color:#fff; }
+.thg-btn-danger{ background:#ef4444; border-color:#ef4444; color:#fff; }
+
+/* Responsive */
+@media (max-width:480px){
+  .thg-auth-wrap{ top:10px; right:10px; }
+  .thg-auth-modal{ width:calc(100% - 16px); margin:0 8px; }
+  .thg-auth-menu{ right:8px; }
+}
+
+/* tagline styling */
+.thg-tagline{ color:#9ca3af; font-size:13px; margin:-4px 0 12px; }
+`;
+      const style = document.createElement('style');
+      style.id = 'thg-auth-styles';
+      style.textContent = css;
+      document.head.appendChild(style);
+    }
+
+    function createUI(){
+      const wrap = ensureContainer();
+      let btn = wrap.querySelector('.thg-auth-btn');
+      if (!btn){
+        btn = createEl('button', 'thg-auth-btn', { type:'button', 'aria-haspopup':'menu', 'aria-expanded':'false', 'aria-label':'Open account menu' });
+        const avatar = createEl('span', 'thg-initial');
+        avatar.textContent = 'U';
+        const label = document.createElement('span');
+        label.className = 'thg-label';
+        const spinner = createEl('span','thg-spinner',{'aria-hidden':'true'});
+        btn.appendChild(avatar); btn.appendChild(label); btn.appendChild(spinner);
+        wrap.appendChild(btn);
+      }
+
+      let menu = wrap.querySelector('.thg-auth-menu');
+      if (!menu){
+        menu = createEl('div', 'thg-auth-menu', { id:'thg-auth-menu', role:'menu', 'aria-hidden':'true' });
+        menu.innerHTML = '<div class="thg-auth-item is-header" aria-disabled="true">' +
+          '<span class="thg-initial-lg">U</span>' +
+          '<span class="thg-name-wrap">' +
+          '<span class="thg-name">User</span>' +
+          '<span class="thg-email">email@example.com</span>' +
+          '</span>' +
+          '</div>' +
+          '<div class="thg-auth-sep"></div>' +
+          '<div class="thg-auth-item" role="menuitem" tabindex="0" data-action="profile"><span>Profile</span></div>' +
+          '<div class="thg-auth-item" role="menuitem" tabindex="0" data-action="dashboard"><span>Dashboard</span></div>' +
+          (AUTH_NAV.settings ? '<div class="thg-auth-item" role="menuitem" tabindex="0" data-action="settings"><span>Settings</span></div>' : '') +
+          '<div class="thg-auth-item" role="menuitem" tabindex="0" data-action="logout"><span>Logout</span></div>';
+        wrap.appendChild(menu);
+      }
+      btn.setAttribute('aria-controls','thg-auth-menu');
+
+      let overlay = document.querySelector('.thg-auth-overlay');
+      if (!overlay){
+        overlay = createEl('div','thg-auth-overlay',{'aria-hidden':'true','aria-modal':'true','role':'dialog'});
+        overlay.innerHTML = `
+          <div class="thg-auth-modal" role="document" aria-labelledby="thg-auth-title">
+            <div class="thg-auth-header">
+              <div class="thg-auth-title" id="thg-auth-title">Sign in to continue</div>
+              <button class="thg-auth-close" type="button" aria-label="Close">✕</button>
+            </div>
+            <div class="thg-loading-bar" aria-hidden="true"></div>
+            <div class="thg-auth-body">
+              <div class="thg-tagline">"Browse only approved builder projects — safe, transparent, and verified"</div>
+              <div class="thg-tabs" role="tablist" aria-label="Authentication method">
+                <button class="thg-tab" role="tab" id="thg-tab-signin" aria-controls="thg-panel-signin" aria-selected="true">Sign in</button>
+                <button class="thg-tab" role="tab" id="thg-tab-signup" aria-controls="thg-panel-signup" aria-selected="false">Create account</button>
+              </div>
+              <div class="thg-error" role="alert"></div>
+              <div id="thg-panel-signin" role="tabpanel" aria-labelledby="thg-tab-signin">
+                <div class="thg-field"><label for="thg-si-email">Email</label><input id="thg-si-email" class="thg-input" type="email" autocomplete="email" placeholder="you@example.com" /></div>
+                <div class="thg-field"><label for="thg-si-password">Password</label><input id="thg-si-password" class="thg-input" type="password" autocomplete="current-password" placeholder="Your password" /></div>
+                <div class="thg-actions"><button class="thg-link" type="button" id="thg-forgot">Forgot password?</button><span class="thg-hint"></span></div>
+                <button class="thg-btn-primary" type="button" id="thg-signin-btn">Sign in</button>
+                <div class="thg-oauth"><button class="thg-oauth-btn google" type="button" data-provider="google">Continue with Google</button></div>
+              </div>
+              <div id="thg-panel-signup" role="tabpanel" aria-labelledby="thg-tab-signup" hidden>
+                <div class="thg-field"><label for="thg-su-name">Full name (optional)</label><input id="thg-su-name" class="thg-input" type="text" autocomplete="name" placeholder="Ada Lovelace" /></div>
+                <div class="thg-field"><label for="thg-su-email">Email</label><input id="thg-su-email" class="thg-input" type="email" autocomplete="email" placeholder="you@example.com" /></div>
+                <div class="thg-field"><label for="thg-su-password">Password</label><input id="thg-su-password" class="thg-input" type="password" autocomplete="new-password" placeholder="At least 8 characters" /></div>
+                <div class="thg-actions"><span class="thg-hint">Use a strong password. You can add name later.</span></div>
+                <button class="thg-btn-primary" type="button" id="thg-signup-btn">Create account</button>
+                <div class="thg-oauth"><button class="thg-oauth-btn google" type="button" data-provider="google">Sign up with Google</button></div>
+              </div>
+              <div id="thg-panel-reset" role="tabpanel" aria-labelledby="thg-tab-reset" hidden>
+                <div class="thg-field"><label for="thg-rp-email">Email</label><input id="thg-rp-email" class="thg-input" type="email" autocomplete="email" placeholder="you@example.com" /></div>
+                <div class="thg-actions"><span class="thg-hint">We’ll email a password reset link.</span></div>
+                <button class="thg-btn-primary" type="button" id="thg-reset-btn">Send reset link</button>
+              </div>
+              <div id="thg-panel-update" role="tabpanel" aria-labelledby="thg-tab-update" hidden>
+                <div class="thg-field"><label for="thg-up-password">New password</label><input id="thg-up-password" class="thg-input" type="password" autocomplete="new-password" placeholder="Enter a new password" /></div>
+                <div class="thg-actions"><span class="thg-hint">You’re recovering your account.</span></div>
+                <button class="thg-btn-primary" type="button" id="thg-update-btn">Update password</button>
+              </div>
+            </div>
+          </div>`;
+        document.body.appendChild(overlay);
+      }
+
+      let confirmEl = document.querySelector('.thg-confirm');
+      if (!confirmEl){
+        confirmEl = createEl('div','thg-confirm',{'aria-hidden':'true','role':'dialog','aria-modal':'true'});
+        confirmEl.innerHTML = '<div class="thg-confirm-card" role="document">' +
+          '<div class="thg-confirm-msg">Are you sure you want to log out?</div>' +
+          '<div class="thg-confirm-actions">' +
+          '<button type="button" class="thg-btn thg-confirm-cancel">Cancel</button>' +
+          '<button type="button" class="thg-btn thg-btn-danger thg-confirm-ok">Log out</button>' +
+          '</div></div>';
+        document.body.appendChild(confirmEl);
+      }
+      return { wrap, btn, menu, overlay, confirmEl };
+    }
+
+    const state = { user: null, loading: true, nextUrl: null, supabaseReady: false, sub: null };
+
+    function setButtonLoading(ui, isLoading){ const spinner = ui.btn.querySelector('.thg-spinner'); const label = ui.btn.querySelector('.thg-label'); if (isLoading){ ui.btn.classList.remove('is-auth'); if (label) label.textContent = 'Loading…'; if (spinner) spinner.style.display = 'inline-block'; ui.btn.setAttribute('aria-expanded','false'); } else { if (spinner) spinner.style.display = 'none'; } }
+
+    function render(ui){
+      const label = ui.btn.querySelector('.thg-label');
+      const avatar = ui.btn.querySelector('.thg-initial');
+      if (state.loading){ setButtonLoading(ui, true); return; }
+      setButtonLoading(ui, false);
+      if (state.user && state.user.email){
+        const name = getDisplayName(state.user);
+        ui.btn.classList.add('is-auth');
+        avatar.textContent = getInitials(state.user);
+        label.textContent = clamp(name, 24);
+        ui.btn.prepend(avatar);
+        const initEl = ui.menu.querySelector('.thg-initial-lg');
+        const nameEl = ui.menu.querySelector('.thg-name');
+        const emailEl = ui.menu.querySelector('.thg-email');
+        if (initEl) initEl.textContent = getInitials(state.user);
+        if (nameEl) nameEl.textContent = clamp(name, 28);
+        if (emailEl) emailEl.textContent = clamp(state.user.email || '', 30);
+      } else {
+        ui.btn.classList.remove('is-auth');
+        ui.btn.setAttribute('aria-expanded','false');
+        label.textContent = 'Login / Signup';
+        avatar.textContent = 'U';
+        ui.btn.prepend(avatar);
+        closeMenu(ui);
+      }
+    }
+
+    function openMenu(ui){ if (!state.user) return; ui.menu.setAttribute('aria-hidden','false'); ui.btn.setAttribute('aria-expanded','true'); const items = ui.menu.querySelectorAll('.thg-auth-item[role="menuitem"]'); if (items[0]) setTimeout(function(){ items[0].focus(); }, 0); }
+    function closeMenu(ui){ ui.menu.setAttribute('aria-hidden','true'); ui.btn.setAttribute('aria-expanded','false'); }
+    function toggleMenu(ui){ const isHidden = ui.menu.getAttribute('aria-hidden') === 'true'; if (isHidden) openMenu(ui); else closeMenu(ui); }
+
+    function showError(uiOverlay, msg){ const el = uiOverlay.querySelector('.thg-error'); if (!el) return; el.textContent = msg; el.style.display = 'block'; }
+    function clearError(uiOverlay){ const el = uiOverlay.querySelector('.thg-error'); if (!el) return; el.textContent = ''; el.style.display = 'none'; }
+    function setModalLoading(uiOverlay, loading){ const bar = uiOverlay.querySelector('.thg-loading-bar'); if (!bar) return; if (loading){ bar.style.width = '75%'; } else { bar.style.width = '0'; } }
+    function showPanel(uiOverlay, id, title){ ['signin','signup','reset','update'].forEach(function(key){ const panel = uiOverlay.querySelector('#thg-panel-'+key); if (panel) panel.hidden = (key !== id); }); const tEl = uiOverlay.querySelector('#thg-auth-title'); if (tEl) tEl.textContent = title; clearError(uiOverlay); }
+    function openAuthModal(ui, opts){ state.nextUrl = opts?.next || null; ui.overlay.setAttribute('aria-hidden','false'); showPanel(ui.overlay, 'signin', 'Sign in'); setTimeout(function(){ const el = ui.overlay.querySelector('#thg-si-email'); if (el) el.focus(); }, 0); }
+    function closeAuthModal(ui){ ui.overlay.setAttribute('aria-hidden','true'); }
+    function openConfirm(ui){ ui.confirmEl.setAttribute('aria-hidden','false'); }
+    function closeConfirm(ui){ ui.confirmEl.setAttribute('aria-hidden','true'); }
+
+    function bindUI(ui){
+      ui.btn.addEventListener('click', function(e){ e.preventDefault(); if (state.user && state.user.email){ toggleMenu(ui); } else { openAuthModal(ui, { next: location.pathname + location.search }); } });
+      ui.btn.addEventListener('keydown', function(e){ if ((e.key === 'ArrowDown' || e.key === 'Enter') && state.user && state.user.email){ e.preventDefault(); openMenu(ui); } });
+      ui.menu.addEventListener('click', function(e){ const item = e.target.closest('.thg-auth-item[role="menuitem"]'); if (!item) return; const act = item.getAttribute('data-action'); if (act === 'profile'){ closeMenu(ui); location.href = AUTH_NAV.profile; return; } if (act === 'dashboard'){ closeMenu(ui); location.href = AUTH_NAV.dashboard; return; } if (act === 'settings' && AUTH_NAV.settings){ closeMenu(ui); location.href = AUTH_NAV.settings; return; } if (act === 'logout'){ closeMenu(ui); openConfirm(ui); } });
+      ui.menu.addEventListener('keydown', function(e){ if (e.key === 'Escape'){ e.preventDefault(); closeMenu(ui); ui.btn.focus(); return; } if (['ArrowDown','ArrowUp','Home','End'].indexOf(e.key) === -1) return; e.preventDefault(); const items = Array.prototype.slice.call(ui.menu.querySelectorAll('.thg-auth-item[role="menuitem"]')); const idx = items.indexOf(document.activeElement); if (!items.length) return; if (e.key === 'Home'){ items[0].focus(); return; } if (e.key === 'End'){ items[items.length - 1].focus(); return; } const next = e.key === 'ArrowDown' ? (idx + 1 + items.length) % items.length : (idx - 1 + items.length) % items.length; items[next].focus(); });
+      document.addEventListener('click', function(e){ if (ui.menu.getAttribute('aria-hidden') === 'true') return; if (!ui.menu.contains(e.target) && e.target !== ui.btn && !ui.btn.contains(e.target)){ closeMenu(ui); } });
+      const tabSignIn = ui.overlay.querySelector('#thg-tab-signin');
+      const tabSignUp = ui.overlay.querySelector('#thg-tab-signup');
+      function selectTab(which){ const a = which==='signin'; tabSignIn.setAttribute('aria-selected', a ? 'true' : 'false'); tabSignUp.setAttribute('aria-selected', a ? 'false' : 'true'); showPanel(ui.overlay, a ? 'signin' : 'signup', a ? 'Sign in' : 'Create account'); const first = ui.overlay.querySelector(a ? '#thg-si-email' : '#thg-su-name'); if (first) first.focus(); }
+      tabSignIn.addEventListener('click', function(){ selectTab('signin'); });
+      tabSignUp.addEventListener('click', function(){ selectTab('signup'); });
+      ui.overlay.addEventListener('click', function(e){ if (e.target === ui.overlay) closeAuthModal(ui); });
+      ui.overlay.querySelector('.thg-auth-close').addEventListener('click', function(){ closeAuthModal(ui); });
+      document.addEventListener('keydown', function(e){ if (e.key === 'Escape' && ui.overlay.getAttribute('aria-hidden') === 'false') closeAuthModal(ui); });
+      const forgotBtn = ui.overlay.querySelector('#thg-forgot');
+      forgotBtn.addEventListener('click', function(){ showPanel(ui.overlay, 'reset', 'Reset password'); const el = ui.overlay.querySelector('#thg-rp-email'); const source = ui.overlay.querySelector('#thg-si-email'); if (source && el && source.value) el.value = source.value; if (el) el.focus(); });
+      ui.overlay.querySelector('#thg-signin-btn').addEventListener('click', async function(){ if (!state.supabaseReady){ showError(ui.overlay, 'Authentication is not initialized.'); return; } const email = ui.overlay.querySelector('#thg-si-email').value.trim(); const password = ui.overlay.querySelector('#thg-si-password').value; if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) { showError(ui.overlay, 'Enter a valid email.'); return; } if (!password || password.length < 6) { showError(ui.overlay, 'Enter your password.'); return; } clearError(ui.overlay); setModalLoading(ui.overlay, true); try{ const { error } = await window.supabase.auth.signInWithPassword({ email, password }); if (error) { showError(ui.overlay, error.message || 'Failed to sign in.'); } } catch(ex){ showError(ui.overlay, 'Network error. Please try again.'); } finally { setModalLoading(ui.overlay, false); } });
+      ui.overlay.querySelector('#thg-signup-btn').addEventListener('click', async function(){ if (!state.supabaseReady){ showError(ui.overlay, 'Authentication is not initialized.'); return; } const name = ui.overlay.querySelector('#thg-su-name').value.trim(); const email = ui.overlay.querySelector('#thg-su-email').value.trim(); const password = ui.overlay.querySelector('#thg-su-password').value; if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) { showError(ui.overlay, 'Enter a valid email.'); return; } if (!password || password.length < 8) { showError(ui.overlay, 'Password must be at least 8 characters.'); return; } clearError(ui.overlay); setModalLoading(ui.overlay, true); try{ const { error } = await window.supabase.auth.signUp({ email, password, options: { data: name ? { full_name: name } : {} } }); if (error) { showError(ui.overlay, error.message || 'Failed to create account.'); } else { showError(ui.overlay, 'Check your email to verify your account.'); } } catch(ex){ showError(ui.overlay, 'Network error. Please try again.'); } finally { setModalLoading(ui.overlay, false); } });
+      ui.overlay.querySelectorAll('.thg-oauth-btn').forEach(function(btn){ btn.addEventListener('click', async function(){ if (!state.supabaseReady){ showError(ui.overlay, 'Authentication is not initialized.'); return; } const provider = btn.getAttribute('data-provider'); clearError(ui.overlay); setModalLoading(ui.overlay, true); try{ const redirectTo = location.origin + location.pathname + location.search; const { data, error } = await window.supabase.auth.signInWithOAuth({ provider, options: { redirectTo, skipBrowserRedirect: true, queryParams: { prompt: 'select_account' } } }); if (error) { const msg = /provider is not enabled/i.test(error.message||'') ? 'Google sign-in is not available yet.' : (error.message || 'Could not start sign in.'); showError(ui.overlay, msg); setModalLoading(ui.overlay, false); return; } if (data && data.url){ location.href = data.url; } else { setModalLoading(ui.overlay, false); showError(ui.overlay, 'Could not start ' + provider + ' sign in.'); } } catch(ex){ showError(ui.overlay, 'Failed to start ' + provider + ' sign in.'); setModalLoading(ui.overlay, false); } }); });
+      ui.overlay.querySelector('#thg-reset-btn').addEventListener('click', async function(){ if (!state.supabaseReady){ showError(ui.overlay, 'Authentication is not initialized.'); return; } const email = ui.overlay.querySelector('#thg-rp-email').value.trim(); if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) { showError(ui.overlay, 'Enter a valid email.'); return; } clearError(ui.overlay); setModalLoading(ui.overlay, true); try{ const redirectTo = location.origin + location.pathname + location.search; const { error } = await window.supabase.auth.resetPasswordForEmail(email, { redirectTo }); if (error) { showError(ui.overlay, error.message || 'Failed to send reset link.'); } else { showError(ui.overlay, 'Reset link sent. Check your email.'); } } catch(ex){ showError(ui.overlay, 'Network error. Please try again.'); } finally { setModalLoading(ui.overlay, false); } });
+      ui.overlay.querySelector('#thg-update-btn').addEventListener('click', async function(){ if (!state.supabaseReady){ showError(ui.overlay, 'Authentication is not initialized.'); return; } const password = ui.overlay.querySelector('#thg-up-password').value; if (!password || password.length < 8) { showError(ui.overlay, 'Password must be at least 8 characters.'); return; } clearError(ui.overlay); setModalLoading(ui.overlay, true); try{ const { error } = await window.supabase.auth.updateUser({ password }); if (error) { showError(ui.overlay, error.message || 'Failed to update password.'); } else { showPanel(ui.overlay, 'signin', 'Sign in'); showError(ui.overlay, 'Password updated. Please sign in.'); } } catch(ex){ showError(ui.overlay, 'Network error. Please try again.'); } finally { setModalLoading(ui.overlay, false); } });
+      ui.confirmEl.querySelector('.thg-confirm-cancel').addEventListener('click', function(){ closeConfirm(ui); });
+      ui.confirmEl.addEventListener('click', function(e){ if (e.target === ui.confirmEl) closeConfirm(ui); });
+      ui.confirmEl.querySelector('.thg-confirm-ok').addEventListener('click', async function(){ try { await window.supabase?.auth?.signOut?.(); } catch(_){} closeConfirm(ui); });
+      window.__thgOpenAuthModal = function(opts){ openAuthModal(ui, opts); };
+      // Expose a helper to programmatically trigger the header button from anywhere
+      window.authGate.triggerHeaderLogin = function(opts){
+        try { ui.btn && ui.btn.click(); }
+        catch(_){ try { openAuthModal(ui, opts||{ next: location.pathname + location.search }); } catch(__){} }
+      };
+    }
+
+    async function initSupabase(ui){
+      state.loading = true; render(ui);
+      if (!window.supabase || !window.supabase.auth){
+        try {
+          const mod = await import('https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm');
+          const client = mod.createClient('https://wedevtjjmdvngyshqdro.supabase.co','eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndlZGV2dGpqbWR2bmd5c2hxZHJvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU0NzYwMzgsImV4cCI6MjA3MTA1MjAzOH0.Ex2c_sx358dFdygUGMVBohyTVto6fdEQ5nydDRh9m6M');
+          window.supabase = client;
+        } catch(_) {}
+      }
+      if (!window.supabase || !window.supabase.auth){ state.supabaseReady = false; state.loading = false; render( ui); console.warn('[thg-auth] window.supabase not found.'); return; }
+      state.supabaseReady = true;
+      try{ const { data } = await window.supabase.auth.getSession(); state.user = data?.session?.user || null; } catch(_){ state.user = null; } finally { state.loading = false; render(ui); }
+      try{
+        const { data: sub } = window.supabase.auth.onAuthStateChange(function(event, session){ state.user = session?.user || null; render(ui); if (event === 'PASSWORD_RECOVERY'){ const overlay = ui.overlay; overlay.setAttribute('aria-hidden','false'); showPanel(overlay, 'update', 'Set new password'); setTimeout(function(){ const el = overlay.querySelector('#thg-up-password'); if (el) el.focus(); }, 0); } if (state.user && state.user.email){ if (state.nextUrl){ const to = state.nextUrl; state.nextUrl = null; try { closeAuthModal(ui); } catch(_){} location.href = to; } else { try { closeAuthModal(ui); } catch(_){} } } else { closeMenu(ui); } });
+        state.sub = sub?.subscription || sub || null;
+      } catch(_){ }
+    }
+
+    function observeRerenders(){ const mo = new MutationObserver(function(muts){ for (var i=0;i<muts.length;i++){ for (var j=0;j<muts[i].addedNodes.length;j++){ const n = muts[i].addedNodes[j]; if (n.nodeType !== 1) continue; hideLegacyAuthLinks(n); ensureContainer(); } } }); mo.observe(document.documentElement, { childList:true, subtree:true }); }
+
+    ready(function(){ hideLegacyAuthLinks(document); injectStyles(); const ui = createUI(); bindUI(ui); observeRerenders(); initSupabase(ui); window.addEventListener('storage', function(ev){ if (ev.key === 'supabase.auth.token'){ } }); window.addEventListener('beforeunload', function(){ try { state.sub && state.sub.unsubscribe && state.sub.unsubscribe(); } catch(_){} }); });
+  })();
+  </script>
+  <!-- END durable-auth-head.html include -->
   
   <!-- Durable top-right authentication header and modal (inline UI) [disabled; use durable-auth-head.html] -->
   <script type="text/plain" data-disabled="true">


### PR DESCRIPTION
Integrate the global login/signup modal into the buyer form page to ensure the CTA button opens the full-window authentication experience.

The previous setup for the buyer form's CTA button did not open the consistent, full-window login/signup container used elsewhere on the site (e.g., from the header). By embedding the `durable-auth-head.html` snippet and wiring the CTA to its logic, users are now directed to the standard, Google-connected authentication flow, with form data preserved via `sessionStorage`.

---
<a href="https://cursor.com/background-agent?bcId=bc-72b2a0d8-efa6-4972-964a-777f02345fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-72b2a0d8-efa6-4972-964a-777f02345fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

