### PR TITLE
Investigate buyer form cta login signup trigger

### DIFF
--- a/buyer-form/index.html
+++ b/buyer-form/index.html
@@ -1527,8 +1527,6 @@ async function getRecaptcha() {
       sessionStorage.setItem('tharaga_pending_form_ts', String(Date.now()));
     } catch (_) {}
 
-    alert('Please sign in first.');
-
     const nextUrl = location.pathname + location.search;
 
     // If this page is embedded inside auth-gate's iframe, ask parent to open the global modal
@@ -1539,17 +1537,19 @@ async function getRecaptcha() {
       }
     } catch(_) {}
 
-    // Prefer clicking the top-right durable header button if present
+    // Prefer global header trigger API first
+    if (window.authGate && typeof window.authGate.triggerHeaderLogin === 'function') {
+      try { window.authGate.triggerHeaderLogin({ next: nextUrl }); return; } catch(_) {}
+    }
+
+    // Then try clicking the top-right durable header button if present
     try {
       const headerBtn = document.querySelector('.thg-auth-btn');
       if (headerBtn) { headerBtn.click(); return; }
     } catch(_) {}
 
-    // Fallbacks: unified auth modal APIs
-    if (window.authGate?.triggerHeaderLogin) {
-      try { window.authGate.triggerHeaderLogin({ next: nextUrl }); return; } catch(_) {}
-    }
-    if (window.authGate?.openLoginModal) {
+    // Fallbacks: open via authGate or local modal
+    if (window.authGate && typeof window.authGate.openLoginModal === 'function') {
       try { window.authGate.openLoginModal({ next: nextUrl }); return; } catch(_) {}
     }
     if (typeof window.__thgOpenAuthModal === 'function') {


### PR DESCRIPTION
Prioritize global header login trigger for buyer form CTA to ensure consistent authentication flow.

The previous implementation used an alert and had a different order of fallback mechanisms for opening the login modal, which did not consistently trigger the global header's login/signup modal. This change ensures that clicking the "Get My Property Matches" CTA when logged out reliably opens the top-right global Login/Signup modal, aligning with expected behavior across the site.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dec0b5e-6891-4eb3-ba5e-eb6f6dca764f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4dec0b5e-6891-4eb3-ba5e-eb6f6dca764f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

