### PR TITLE
Debug Netlify deployment issues

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -27,3 +27,13 @@
   from = "/auth/*"
   to = "/public/auth/:splat"
   status = 200
+
+[[redirects]]
+  from = "/snippets"
+  to = "/snippets/durable-auth-head.html"
+  status = 301
+
+[[redirects]]
+  from = "/snippets/"
+  to = "/snippets/durable-auth-head.html"
+  status = 200


### PR DESCRIPTION
Add Netlify redirects to serve `durable-auth-head.html` for `/snippets` paths, fixing a 404 error.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a312466-e1de-4ae4-a5ed-e251ccfb0d6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9a312466-e1de-4ae4-a5ed-e251ccfb0d6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

