### PR TITLE
Implement iframe to parent durable header communication

### DIFF
--- a/buyer-form/index.html
+++ b/buyer-form/index.html
@@ -1528,11 +1528,13 @@ async function getRecaptcha() {
     } catch (_) {}
 
     const nextUrl = location.pathname + location.search;
+    const PARENT_ORIGIN = 'https://tharaga.co.in';
 
-    // If this page is embedded inside auth-gate's iframe, ask parent to open the global modal
+    // If this page is embedded inside an iframe, securely ask parent to open the global header/modal
     try {
       if (window.self !== window.parent) {
-        window.parent.postMessage({ type: 'open_login_modal', next: nextUrl }, '*');
+        const message = { type: 'cta', action: 'openDurableHead', meta: { from: 'feature-iframe', id: 'buyer-form', next: nextUrl, timestamp: Date.now() } };
+        window.parent.postMessage(message, PARENT_ORIGIN);
         return;
       }
     } catch(_) {}

--- a/snippets/index.html
+++ b/snippets/index.html
@@ -529,13 +529,37 @@
     } catch(_){}
 
     // Allow child iframes (e.g., Netlify buyer-form) to request opening the global login
+    // Secure origin-validated postMessage listener (also supports legacy types)
+    const ALLOWED_IFRAME_ORIGINS = ['https://auth.tharaga.co.in'];
+
+    function openDurableHeaderBehavior(meta){
+      try {
+        var el = document.getElementById('durable-head')
+          || document.querySelector('header, [role="banner"], [data-section="header"], .site-header, nav')
+          || document.querySelector('.thg-auth-wrap');
+        if (el && el.scrollIntoView) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+        if (ui && ui.btn) { ui.btn.click(); }
+      } catch (err) { console.error('openDurableHeaderBehavior error:', err); }
+    }
+    window.openDurableHeaderBehavior = openDurableHeaderBehavior;
+
     window.addEventListener('message', function(ev){
       try {
         var data = ev && ev.data;
         if (!data || typeof data !== 'object') return;
+        if (ev.origin && ALLOWED_IFRAME_ORIGINS.indexOf(ev.origin) === -1) return;
+
+        if (data.type === 'cta' && data.action === 'openDurableHead'){
+          console.log('Parent received openDurableHead from', ev.origin, data);
+          openDurableHeaderBehavior(data.meta || {});
+          return;
+        }
+
         if (data.type === 'open_login_modal' || data.type === 'auth_open' || data.type === 'login_open' || data.type === 'trigger_header_login'){
           try { ui.btn && ui.btn.click(); return; } catch(_){ }
-          try { openAuthModal(ui, { next: data.next || (location.pathname + location.search) }); } catch(_){}
+          try { openAuthModal(ui, { next: data.next || (location.pathname + location.search) }); } catch(_){ }
         }
       } catch(_){ }
     });


### PR DESCRIPTION
Add secure `postMessage` flow for iframe CTAs to open the parent's durable header login/signup UI.

This enables the buyer-form's "Get My Property Matches" button to trigger the parent site's login/signup modal via a secure `postMessage` when a user is not logged in, preventing full page navigation and improving the user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c0207b4-8e96-4c6f-af15-ca4af90b772b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c0207b4-8e96-4c6f-af15-ca4af90b772b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

