### PR TITLE
Fix duplicate dropdown opening after login

### DIFF
--- a/buyer-form/index.html
+++ b/buyer-form/index.html
@@ -1179,19 +1179,18 @@ async function getRecaptcha() {
       try { window.authGate.triggerHeaderLogin({ next: nextUrl }); return; } catch(_) {}
     }
 
-    // Then try clicking the top-right durable header button if present
-    try {
-      const headerBtn = document.querySelector('.thg-auth-btn');
-      if (headerBtn) { headerBtn.click(); return; }
-    } catch(_) {}
-
-    // Fallbacks: open via authGate or local modal
+    // Open login modal without toggling the header dropdown
     if (window.authGate && typeof window.authGate.openLoginModal === 'function') {
       try { window.authGate.openLoginModal({ next: nextUrl }); return; } catch(_) {}
     }
     if (typeof window.__thgOpenAuthModal === 'function') {
       try { window.__thgOpenAuthModal({ next: nextUrl }); return; } catch(_) {}
     }
+    // Last resort: only click header button if it is not in authenticated state
+    try {
+      const headerBtn = document.querySelector('.thg-auth-btn');
+      if (headerBtn && !headerBtn.classList.contains('is-auth')) { headerBtn.click(); return; }
+    } catch(_) {}
     return;
   }
 
@@ -1463,21 +1462,22 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
     } catch(_) {}
 
-    // Prefer header trigger helper
-    if (window.authGate && typeof window.authGate.triggerHeaderLogin === 'function') {
-      try { window.authGate.triggerHeaderLogin({ next: nextUrl }); return; } catch(_) {}
-    }
-
-    // Fallback: click the header button if present
-    try { const btn = document.querySelector('.thg-auth-btn'); if (btn) { btn.click(); return; } } catch(_) {}
-
-    // Fallbacks: open via authGate or local inline
+    // Prefer opening the modal directly to avoid toggling an already-auth dropdown
     if (window.authGate && typeof window.authGate.openLoginModal === 'function') {
       try { window.authGate.openLoginModal({ next: nextUrl }); return; } catch(_) {}
     }
     if (typeof window.__thgOpenAuthModal === 'function') {
       try { window.__thgOpenAuthModal({ next: nextUrl }); return; } catch(_) {}
     }
+    // Fallback: header trigger helper (safe when not authenticated)
+    if (window.authGate && typeof window.authGate.triggerHeaderLogin === 'function') {
+      try { window.authGate.triggerHeaderLogin({ next: nextUrl }); return; } catch(_) {}
+    }
+    // Last resort: only click header button if it is not in authenticated state
+    try {
+      const btn = document.querySelector('.thg-auth-btn');
+      if (btn && !btn.classList.contains('is-auth')) { btn.click(); return; }
+    } catch(_) {}
   }, true);
 });
 </script>

--- a/search-filter-home/index.html
+++ b/search-filter-home/index.html
@@ -308,10 +308,16 @@
               try { window.authGate.triggerHeaderLogin({ next }); } catch(_) {}
               return;
             }
+            // Prefer opening modal directly to avoid toggling an already-auth dropdown
             if (window.authGate && typeof window.authGate.openLoginModal === 'function') {
               try { window.authGate.openLoginModal({ next }); } catch(_) {}
               return;
             }
+            // As a last resort, only click header button if not authenticated
+            try {
+              const btn = document.querySelector('.thg-auth-btn');
+              if (btn && !btn.classList.contains('is-auth')) { btn.click(); return; }
+            } catch(_) {}
             runGo();
           } catch (e) { console.error('manualGateHandler error', e); }
         }


### PR DESCRIPTION
Prevent buyer form and home search CTAs from opening the user dropdown when already logged in.

The "Get My Property Matches" and "Search" buttons were using a shared header trigger (`.thg-auth-btn`) which, when clicked by an authenticated user, toggles the user profile dropdown instead of proceeding with the intended action (e.g., opening a login modal or submitting a form). This change prioritizes opening the login modal directly or proceeding with the action, only falling back to clicking the header button if the user is not authenticated.

---
<a href="https://cursor.com/background-agent?bcId=bc-63dade6b-630e-4aed-a022-13343c5f06dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63dade6b-630e-4aed-a022-13343c5f06dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

