### PR TITLE
Fix duplicate dropdown opening and cta navigation

### DIFF
--- a/buyer-form/index.html
+++ b/buyer-form/index.html
@@ -1150,6 +1150,7 @@ async function getRecaptcha() {
  // Submit: embed → RPC → render
   matchForm.addEventListener("submit", async (e) => {
   e.preventDefault();
+  e.stopPropagation();
 
   // Check session
   const currentUser = await (window.ensureSupabaseSession?.()) || (await window.supabase?.auth.getSession()).data?.session?.user || null;
@@ -1174,11 +1175,6 @@ async function getRecaptcha() {
       }
     } catch(_) {}
 
-    // Prefer global header trigger API first
-    if (window.authGate && typeof window.authGate.triggerHeaderLogin === 'function') {
-      try { window.authGate.triggerHeaderLogin({ next: nextUrl }); return; } catch(_) {}
-    }
-
     // Open login modal without toggling the header dropdown
     if (window.authGate && typeof window.authGate.openLoginModal === 'function') {
       try { window.authGate.openLoginModal({ next: nextUrl }); return; } catch(_) {}
@@ -1186,11 +1182,6 @@ async function getRecaptcha() {
     if (typeof window.__thgOpenAuthModal === 'function') {
       try { window.__thgOpenAuthModal({ next: nextUrl }); return; } catch(_) {}
     }
-    // Last resort: only click header button if it is not in authenticated state
-    try {
-      const headerBtn = document.querySelector('.thg-auth-btn');
-      if (headerBtn && !headerBtn.classList.contains('is-auth')) { headerBtn.click(); return; }
-    } catch(_) {}
     return;
   }
 
@@ -1469,15 +1460,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (typeof window.__thgOpenAuthModal === 'function') {
       try { window.__thgOpenAuthModal({ next: nextUrl }); return; } catch(_) {}
     }
-    // Fallback: header trigger helper (safe when not authenticated)
-    if (window.authGate && typeof window.authGate.triggerHeaderLogin === 'function') {
-      try { window.authGate.triggerHeaderLogin({ next: nextUrl }); return; } catch(_) {}
-    }
-    // Last resort: only click header button if it is not in authenticated state
-    try {
-      const btn = document.querySelector('.thg-auth-btn');
-      if (btn && !btn.classList.contains('is-auth')) { btn.click(); return; }
-    } catch(_) {}
+    // Avoid programmatically clicking the header button entirely
   }, true);
 });
 </script>

--- a/property-listing/listings.js
+++ b/property-listing/listings.js
@@ -155,10 +155,10 @@ function applyQueryParams(){
 
     // Apply pills (Buy/Rent/Commercial)
     if (pillType) {
+      // Persist desired pill so wireUI picks it up reliably even if not yet bound
+      try { localStorage.setItem('activeFilterType', pillType); } catch(_) {}
       const pill = document.querySelector(`.filter-pill[data-type="${pillType}"]`);
-      if (pill) {
-        pill.click(); // triggers debounced apply inside wireUI
-      }
+      if (pill) { try { pill.click(); } catch(_) {} }
     }
 
     // Budget handling: supports label like "₹1Cr – ₹2Cr" or numeric minPrice/maxPrice

--- a/search-filter-home/index.html
+++ b/search-filter-home/index.html
@@ -296,6 +296,7 @@
             if (!loggedIn && window.__authGateLoggedIn) loggedIn = true;
             if (loggedIn) { runGo(); return; }
             evt.preventDefault && evt.preventDefault();
+            evt.stopPropagation && evt.stopPropagation();
             const next = (location.pathname + location.search);
             // If embedded, ask parent to open the global modal
             try {
@@ -304,20 +305,11 @@
                 return;
               }
             } catch(_) {}
-            if (window.authGate && typeof window.authGate.triggerHeaderLogin === 'function') {
-              try { window.authGate.triggerHeaderLogin({ next }); } catch(_) {}
-              return;
-            }
             // Prefer opening modal directly to avoid toggling an already-auth dropdown
             if (window.authGate && typeof window.authGate.openLoginModal === 'function') {
               try { window.authGate.openLoginModal({ next }); } catch(_) {}
               return;
             }
-            // As a last resort, only click header button if not authenticated
-            try {
-              const btn = document.querySelector('.thg-auth-btn');
-              if (btn && !btn.classList.contains('is-auth')) { btn.click(); return; }
-            } catch(_) {}
             runGo();
           } catch (e) { console.error('manualGateHandler error', e); }
         }


### PR DESCRIPTION
Prevent the home page search button from opening the authentication dropdown by stopping event propagation and removing the programmatic click on the auth button.

---
<a href="https://cursor.com/background-agent?bcId=bc-30043a64-9d43-495e-a420-87b955eef1f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30043a64-9d43-495e-a420-87b955eef1f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

