### PR TITLE
Fix buyer form email sync and property matches navigation

### DIFF
--- a/snippets/index.html
+++ b/snippets/index.html
@@ -444,6 +444,29 @@
   function openAuthModal(ui, opts){ state.nextUrl = opts?.next || null; ui.overlay.setAttribute('aria-hidden','false'); showPanel(ui.overlay, 'signin', 'Sign in'); setTimeout(function(){ const el = ui.overlay.querySelector('#thg-si-email'); if (el) el.focus(); }, 0); }
   function closeAuthModal(ui){ ui.overlay.setAttribute('aria-hidden','true'); }
   function openConfirm(ui){ ui.confirmEl.setAttribute('aria-hidden','false'); }
+  // Broadcast current auth state (email only) to child iframes, sibling tabs, and embedded forms
+  function broadcastAuth(user){
+    try { window.__authGateLoggedIn = !!(user && user.email); } catch(_) {}
+    try {
+      localStorage.setItem('__tharaga_magic_continue', JSON.stringify({ user: user ? { email: user.email } : null, ts: Date.now() }));
+    } catch(_) {}
+    try {
+      if ('BroadcastChannel' in window){
+        window.__thgAuthBC = window.__thgAuthBC || new BroadcastChannel('tharaga-auth');
+        window.__thgAuthBC.postMessage({ type:'THARAGA_AUTH_SUCCESS', user: user ? { email: user.email } : null });
+      }
+    } catch(_) {}
+    try {
+      var payload = { type: 'THARAGA_AUTH_SUCCESS', user: user ? { email: user.email } : null };
+      // Notify any embedded iframes (cross-origin safe via postMessage)
+      var iframes = document.querySelectorAll('iframe');
+      for (var i=0;i<iframes.length;i++){
+        try { iframes[i].contentWindow && iframes[i].contentWindow.postMessage(payload, '*'); } catch(__) {}
+      }
+      // If this page itself is inside an iframe, also notify parent
+      try { if (window.parent && window.parent !== window) window.parent.postMessage(payload, '*'); } catch(__) {}
+    } catch(_) {}
+  }
   function closeConfirm(ui){ ui.confirmEl.setAttribute('aria-hidden','true'); }
 
   function bindUI(ui){
@@ -489,9 +512,9 @@
     }
     if (!window.supabase || !window.supabase.auth){ state.supabaseReady = false; state.loading = false; render( ui); console.warn('[thg-auth] window.supabase not found.'); return; }
     state.supabaseReady = true;
-    try{ const { data } = await window.supabase.auth.getSession(); state.user = data?.session?.user || null; } catch(_){ state.user = null; } finally { state.loading = false; render(ui); }
+    try{ const { data } = await window.supabase.auth.getSession(); state.user = data?.session?.user || null; } catch(_){ state.user = null; } finally { state.loading = false; render(ui); try { broadcastAuth(state.user); } catch(__) {} }
     try{
-      const { data: sub } = window.supabase.auth.onAuthStateChange(function(event, session){ state.user = session?.user || null; render(ui); if (event === 'PASSWORD_RECOVERY'){ const overlay = ui.overlay; overlay.setAttribute('aria-hidden','false'); showPanel(overlay, 'update', 'Set new password'); setTimeout(function(){ const el = overlay.querySelector('#thg-up-password'); if (el) el.focus(); }, 0); } if (state.user && state.user.email){ if (state.nextUrl){ const to = state.nextUrl; state.nextUrl = null; try { closeAuthModal(ui); } catch(_){} location.href = to; } else { try { closeAuthModal(ui); } catch(_){} } } else { closeMenu(ui); } });
+      const { data: sub } = window.supabase.auth.onAuthStateChange(function(event, session){ state.user = session?.user || null; render(ui); try { broadcastAuth(state.user); } catch(__) {} if (event === 'PASSWORD_RECOVERY'){ const overlay = ui.overlay; overlay.setAttribute('aria-hidden','false'); showPanel(overlay, 'update', 'Set new password'); setTimeout(function(){ const el = overlay.querySelector('#thg-up-password'); if (el) el.focus(); }, 0); } if (state.user && state.user.email){ if (state.nextUrl){ const to = state.nextUrl; state.nextUrl = null; try { closeAuthModal(ui); } catch(_){} location.href = to; } else { try { closeAuthModal(ui); } catch(_){} } } else { closeMenu(ui); } });
       state.sub = sub?.subscription || sub || null;
     } catch(_){ }
   }


### PR DESCRIPTION
Broadcast user authentication state to sync the buyer-form email field and make it non-editable.

The `snippets/index.html` script now broadcasts the signed-in user's email via `localStorage`, `BroadcastChannel`, and `postMessage` to child iframes and parent windows. This allows embedded forms, like the buyer-form, to automatically populate and disable their email input based on the authenticated user. The "Get my property matches" button was confirmed to already correctly navigate to the listings page with filters.

---
<a href="https://cursor.com/background-agent?bcId=bc-207d14d7-aa00-465f-a0f4-31544386b6a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-207d14d7-aa00-465f-a0f4-31544386b6a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

