### PR TITLE
Fix property filters and buyer form login state

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -33,3 +33,9 @@
   to = "/snippets/"
   status = 301
 
+[[redirects]]
+  from = "/verified-property-listings"
+  to = "/property-listing/"
+  status = 200
+  force = true
+


### PR DESCRIPTION
Add Netlify redirect for `/verified-property-listings` to ensure URL filters are correctly applied to the property listings page.

Previously, submissions from the buyer form and home search landed on a page that did not correctly hydrate filters from the URL, causing the filter UI to not update. This redirect ensures the correct listings page, which handles URL parameter hydration, is loaded.

---
<a href="https://cursor.com/background-agent?bcId=bc-c655119b-b532-4231-aad5-6d87717781f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c655119b-b532-4231-aad5-6d87717781f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

