### PR TITLE
Fix buyer form cta and filter issue

### DIFF
--- a/buyer-form/index.html
+++ b/buyer-form/index.html
@@ -733,10 +733,38 @@
                style="width:100%; padding:10px; border-radius:8px; border:1px solid #ddd;">
       </label>
 
+      <script>
+      (function(){
+        try {
+          var inp = document.querySelector('#buyerForm [name="email"]');
+          if (!inp) return;
+          function readCached(){
+            try { var cached = JSON.parse(localStorage.getItem('__tharaga_magic_continue')||'null'); var em = cached && cached.user && cached.user.email || ''; if (em) return em; } catch(_){}
+            try { var raw = localStorage.getItem('supabase.auth.token'); if (raw){ var j = JSON.parse(raw); var em2 = (j && (j.currentSession && j.currentSession.user && j.currentSession.user.email)) || (j && j.user && j.user.email) || (j && j.session && j.session.user && j.session.user.email) || ''; if (em2) return em2; } } catch(_){}
+            return '';
+          }
+          var email = readCached();
+          if (email){
+            inp.value = email;
+            inp.setAttribute('data-session-email', email);
+            inp.readOnly = true; inp.disabled = true; inp.setAttribute('aria-readonly','true');
+            try { inp.setAttribute('autocomplete','off'); inp.setAttribute('autocapitalize','off'); inp.setAttribute('spellcheck','false'); } catch(_){}
+            try {
+              var hid = document.getElementById('buyer-email-hidden');
+              if (!hid){ hid = document.createElement('input'); hid.type='hidden'; hid.name='email'; hid.id='buyer-email-hidden'; inp.parentElement && inp.parentElement.appendChild(hid); }
+              hid.value = email;
+            } catch(_){ }
+            try { var badge = document.getElementById('emailLockBadge'); if (badge) badge.style.display = 'inline-block'; } catch(_){}
+          }
+        } catch(_){ }
+      })();
+      </script>
+
       <label style="display:block;">
         <span>Email</span>
         <input required type="email" name="email" placeholder="you@example.com"
                style="width:100%; padding:10px; border-radius:8px; border:1px solid #ddd;">
+        <div id="emailLockBadge" style="display:none;margin-top:6px;width:max-content;padding:4px 8px;border-radius:999px;border:1px solid #a7f3d0;background:#ecfdf5;color:#065f46;font-size:12px;font-weight:600;">🔒 Locked to your account</div>
         <small id="emailNotice" style="display:none;color:#b45309;margin-top:6px;display:block;">
           Please enter your account email shown at the top-right header.
         </small>
@@ -1706,6 +1734,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         emailInput.disabled = true;
         try { emailInput.setAttribute('data-original-name', 'email'); emailInput.removeAttribute('name'); } catch(_) {}
       } catch(_) {}
+      try { const badge = document.getElementById('emailLockBadge'); if (badge) badge.style.display = 'inline-block'; } catch(_) {}
       try {
         emailInput.addEventListener('beforeinput', prevent);
         emailInput.addEventListener('keydown', prevent);
@@ -1742,6 +1771,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         const hidden = document.getElementById('buyer-email-hidden');
         if (hidden && hidden.parentElement) hidden.parentElement.removeChild(hidden);
       } catch(_) {}
+      try { const badge = document.getElementById('emailLockBadge'); if (badge) badge.style.display = 'none'; } catch(_) {}
     }
 
     // Initial sync from local cache (no network) then confirm with Supabase

--- a/property-listing/index.html
+++ b/property-listing/index.html
@@ -8,8 +8,6 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./styles.css">
   <script src="./config.js"></script>
-  <script type="module" src="./app.js?v=20250823"></script>
-
   <script type="module" src="./listings.js"></script>
 
   <!-- Auth handlers: recover Supabase fragments and provide login modal -->

--- a/property-listing/listings.js
+++ b/property-listing/listings.js
@@ -736,6 +736,16 @@ async function enrichWithMetro(){
 
 async function init(){
   try{
+    // Ensure compare modal starts closed and has basic close handlers bound immediately
+    try {
+      const modalEarly = document.getElementById('compareModal');
+      const closeEarly = document.getElementById('compareClose');
+      const backdropEarly = modalEarly?.querySelector('.compare-backdrop');
+      if (modalEarly) modalEarly.hidden = true;
+      closeEarly?.addEventListener('click', ()=>{ try { modalEarly.hidden = true; } catch(_){} });
+      backdropEarly?.addEventListener('click', ()=>{ try { modalEarly.hidden = true; } catch(_){} });
+    } catch(_) {}
+
     // Early: hydrate from URL so visible controls reflect deep link immediately
     try { applyQueryParams(); } catch(_) {}
 


### PR DESCRIPTION
Remove duplicate script and add early compare modal close handlers to fix filter hydration and modal closing issues.

The `property-listing/index.html` was loading both `app.js` and `listings.js`, which could lead to double initialization of filter logic and prevent query parameters from correctly hydrating the filter controls. Additionally, the "Compare properties" modal (`#compareModal`) was not consistently hidden on page load and its close handlers were not always active, causing it to remain open. This PR addresses these by removing the redundant script and ensuring the modal is hidden by default with immediate close bindings.

---
<a href="https://cursor.com/background-agent?bcId=bc-87177c19-c2bf-4ba1-8c0d-dfce74696077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87177c19-c2bf-4ba1-8c0d-dfce74696077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

