### PR TITLE
Analyze and enhance top features for link

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -4,6 +4,8 @@ const nextConfig = {
   experimental: {
     typedRoutes: true,
   },
+  // Serve Next.js app under /app so the root can host the unified static site
+  basePath: '/app',
   async rewrites() {
     // Ensure /api in Next dev maps to real backend if proxy not present
     const apiBase = process.env.NEXT_PUBLIC_API_URL

--- a/netlify.toml
+++ b/netlify.toml
@@ -36,7 +36,7 @@
 ## Serve unified static homepage at root instead of Next.js app route
 [[redirects]]
   from = "/"
-  to = "/unified.html"
+  to = "/app/unified.html"
   status = 200
   force = true
 


### PR DESCRIPTION
Configure Next.js with a `/app` base path and update Netlify redirects to fix the 404 on `/app` and correctly serve the unified homepage.

The Next.js application was not configured with a base path, leading to a 404 when `/app` was accessed. Simultaneously, the root (`/`) was serving a separate static page. This change correctly mounts the Next.js app at `/app` and ensures the unified static homepage is served correctly from the root.

---
<a href="https://cursor.com/background-agent?bcId=bc-bca2498d-0f8f-4561-8b7e-474030335a47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bca2498d-0f8f-4561-8b7e-474030335a47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

