### PR TITLE
Fix netlify function dependency error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,14 @@
 [build]
   base = "app"
-  command = "npm install && node ../scripts/ensure-next-public-env.mjs && node ../scripts/copy-static.cjs && npm run build"
+  command = "npm install && npm --prefix ../netlify/functions install --no-audit --no-fund --omit=dev && node ../scripts/ensure-next-public-env.mjs && node ../scripts/copy-static.cjs && npm run build"
   publish = ".next"
   functions = "../netlify/functions"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"
+
+[[plugins]]
+  package = "@netlify/plugin-functions-install-core"
 
 
 


### PR DESCRIPTION
Resolve Netlify build failure by ensuring `@supabase/supabase-js` is installed for Netlify Functions.

The Netlify build was failing because the `recommendations.js` function could not find the `@supabase/supabase-js` module. This PR implements two recommended solutions: adding the `@netlify/plugin-functions-install-core` plugin to `netlify.toml` and explicitly running `npm install` within the `netlify/functions` directory as part of the build command.

---
<a href="https://cursor.com/background-agent?bcId=bc-56bcf117-01f7-44c0-a962-58783c2d8fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56bcf117-01f7-44c0-a962-58783c2d8fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

