### PR TITLE
Fix phone number overlap on continue button

### DIFF
--- a/app/public/cta-embed.html
+++ b/app/public/cta-embed.html
@@ -45,11 +45,17 @@
     .row > * { min-width: 0; }
     .field-inline { position: relative; min-width: 0; }
     .field-inline input {
-      width: 100%; min-width: 0; padding: 12px 14px; border-radius: 12px;
+      width: 100%;
+      min-width: 0;
+      padding: 12px 14px;
+      border-radius: 12px;
       border: 1px solid rgba(255,255,255,0.08);
       background: rgba(255,255,255,0.06);
       color: var(--text);
       outline: none;
+      /* Prevent overflow that visually overlaps the button on some browsers */
+      box-sizing: border-box;
+      max-width: 100%;
     }
     .field-inline input::placeholder { color: rgba(255,255,255,0.6); }
     .primary-btn {


### PR DESCRIPTION
Fix phone number input box overflowing and overlapping the 'Continue' button by adjusting its CSS properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac0e8171-44f1-439d-90ef-d7f123deb1a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac0e8171-44f1-439d-90ef-d7f123deb1a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

