### PR TITLE
Analyze and replicate auth embed background image

### DIFF
--- a/app/public/cta-embed.html
+++ b/app/public/cta-embed.html
@@ -362,9 +362,13 @@
       if (inlinePhone) { const el = document.getElementById('cta-phone'); if (el) el.value = inlinePhone; }
 
       // Curated default backgrounds (human-psychology informed)
-      // Principles: warm ambient interiors and soft bokeh drive trust and comfort; city skylines
-      // signal aspiration; subtle greenery reduces stress. We keep them blurred behind the CTA.
+      // Principles: friendly human presence (non‑sexualized) in a warm home setting increases trust;
+      // soft bokeh and interiors reduce cognitive load; skylines signal aspiration; greenery lowers stress.
+      // We keep them blurred behind the CTA.
       const PSY_BG_CATALOG = {
+        // Optimized: friendly host at home (subtle human presence)
+        // Source: Unsplash, license-free for commercial use
+        friendly_host: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?q=80&w=1600&auto=format&fit=crop',
         warm_home: 'https://images.unsplash.com/photo-1493666438817-866a91353ca9?q=80&w=1600&auto=format&fit=crop',
         modern_living: 'https://images.unsplash.com/photo-1505691723518-36a5ac3bcb48?q=80&w=1600&auto=format&fit=crop',
         skyline_twilight: 'https://images.unsplash.com/photo-1499343245400-cddc78a01317?q=80&w=1600&auto=format&fit=crop',
@@ -375,7 +379,7 @@
       // Background image support for embeds (e.g., Durable sections)
       const theme = (params.get('theme') || '').toLowerCase();
       const bgUrl = params.get('bg') || params.get('image') || (
-        theme && PSY_BG_CATALOG[theme] ? PSY_BG_CATALOG[theme] : PSY_BG_CATALOG.warm_home
+        theme && PSY_BG_CATALOG[theme] ? PSY_BG_CATALOG[theme] : PSY_BG_CATALOG.friendly_host
       );
       const bgBlur = parseInt(params.get('blur') || params.get('bg_blur') || '14', 10);
       const bgEl = document.getElementById('bg-img');
@@ -388,6 +392,7 @@
 
       // Accent color control (optionally by theme or &accent=#hex)
       const ACCENTS = {
+        friendly_host: '#6e0d25',
         warm_home: '#6e0d25',
         modern_living: '#284d6f',
         skyline_twilight: '#5b3cc4',

--- a/app/public/js/thg-cta.js
+++ b/app/public/js/thg-cta.js
@@ -36,7 +36,7 @@
       const src = `/cta-embed.html?${qs}`;
 
       const iframe = document.createElement('iframe');
-      iframe.src = src; iframe.loading = 'lazy'; iframe.style.width = '100%'; iframe.style.border = '0'; iframe.style.height = '360px'; iframe.style.display = 'block'; iframe.setAttribute('title','Tharaga CTA');
+      iframe.src = src; iframe.loading = 'lazy'; iframe.style.width = '100%'; iframe.style.border = '0'; iframe.style.height = '300px'; iframe.style.display = 'block'; iframe.setAttribute('title','Tharaga CTA');
       const heightAttr = this.getAttribute('height');
       if (heightAttr) iframe.style.height = /px|vh|%/.test(heightAttr) ? heightAttr : `${parseInt(heightAttr,10)||360}px`;
 

--- a/app/public/snippets/cta-embed-integration.html
+++ b/app/public/snippets/cta-embed-integration.html
@@ -7,7 +7,7 @@
   <style>
     body{font-family:Inter,ui-sans-serif,system-ui;margin:0;padding:20px;background:#f6f4f2;color:#1a1a1a}
     code,pre{background:#111;color:#f6f4f2;padding:10px;border-radius:8px;display:block;overflow:auto}
-    iframe{width:100%;height:420px;border:0;border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,.12)}
+    iframe{width:100%;height:300px;border:0;border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,.12)}
     .card{max-width:900px;margin:0 auto}
   </style>
 </head>
@@ -17,7 +17,7 @@
     <p>This example shows how to embed the CTA and listen for events. Allowed parent origins include <code>tharaga.co.in</code> and <code>auth.tharaga.co.in</code>.</p>
 
     <h3>Embed</h3>
-    <iframe id="ctaFrame" src="/cta-embed.html?embed=cta&open=1&city=Chennai"></iframe>
+    <iframe id="ctaFrame" src="/cta-embed.html?embed=cta&open=1&city=Chennai&theme=friendly_host&blur=14"></iframe>
 
     <h3>Listen for events</h3>
     <pre><code>window.addEventListener('message', (ev) => {

--- a/app/public/snippets/thg-cta-web-component.html
+++ b/app/public/snippets/thg-cta-web-component.html
@@ -14,8 +14,8 @@
   <h1>&lt;thg-cta&gt; web component</h1>
   <p>Drop this anywhere. It renders the embed in a sized iframe.</p>
   <pre><code>&lt;script src="https://auth.tharaga.co.in/js/thg-cta.js" defer&gt;&lt;/script&gt;
-&lt;thg-cta city="Chennai" budget="70L" open&gt;&lt;/thg-cta&gt;</code></pre>
+&lt;thg-cta city="Chennai" theme="friendly_host" blur="14" height="300" open&gt;&lt;/thg-cta&gt;</code></pre>
 
-  <thg-cta city="Chennai" budget="70L" open></thg-cta>
+  <thg-cta city="Chennai" theme="friendly_host" blur="14" height="300" open></thg-cta>
 </body>
 </html>


### PR DESCRIPTION
Set a new psychology-optimized default background image and update the default iframe height to 300px for the CTA embed, improving visual engagement and matching user-specified dimensions.

---
<a href="https://cursor.com/background-agent?bcId=bc-5325beeb-0550-4913-96d1-d6cc6def30ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5325beeb-0550-4913-96d1-d6cc6def30ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

